### PR TITLE
mock WordPress database in tests

### DIFF
--- a/tests/AlertEngineTest.php
+++ b/tests/AlertEngineTest.php
@@ -29,8 +29,9 @@ class AlertEngineTest extends TestCase {
 		parent::setUp();
 
 		// Create mock wpdb
-		$this->wpdb_mock = $this->createMock( stdClass::class );
-		$this->wpdb_mock->prefix = 'wp_';
+                $this->wpdb_mock = $this->createMock( stdClass::class );
+                $this->wpdb_mock->prefix = 'wp_';
+                $this->wpdb_mock->method( 'prepare' )->willReturnArgument( 0 );
 
 		// Set global wpdb
 		global $wpdb;

--- a/tests/AnomalyDetectorTest.php
+++ b/tests/AnomalyDetectorTest.php
@@ -29,8 +29,9 @@ class AnomalyDetectorTest extends TestCase {
 		parent::setUp();
 
 		// Create mock wpdb
-		$this->wpdb_mock = $this->createMock( stdClass::class );
-		$this->wpdb_mock->prefix = 'wp_';
+                $this->wpdb_mock = $this->createMock( stdClass::class );
+                $this->wpdb_mock->prefix = 'wp_';
+                $this->wpdb_mock->method( 'prepare' )->willReturnArgument( 0 );
 
 		// Set global wpdb
 		global $wpdb;

--- a/tests/AudienceSegmentationTest.php
+++ b/tests/AudienceSegmentationTest.php
@@ -5,7 +5,8 @@
  * @package FP_Digital_Marketing_Suite
  */
 
-require_once dirname( __DIR__ ) . '/bootstrap.php';
+// Load the test environment bootstrap.
+require_once __DIR__ . '/bootstrap.php';
 
 use FP\DigitalMarketing\Models\AudienceSegment;
 use FP\DigitalMarketing\Database\AudienceSegmentTable;

--- a/tests/DataExporterTest.php
+++ b/tests/DataExporterTest.php
@@ -146,12 +146,12 @@ class DataExporterTest extends TestCase {
 		// Should contain BOM for UTF-8
 		$this->assertStringStartsWith( "\xEF\xBB\xBF", $csv_content );
 		
-		// Should contain headers
-		$this->assertStringContains( 'name,age,city', $csv_content );
-		
-		// Should contain data
-		$this->assertStringContains( 'John,30,"New York"', $csv_content );
-		$this->assertStringContains( 'Jane,25,London', $csv_content );
+                // Should contain headers
+                $this->assertStringContainsString( 'name,age,city', $csv_content );
+
+                // Should contain data
+                $this->assertStringContainsString( 'John,30,"New York"', $csv_content );
+                $this->assertStringContainsString( 'Jane,25,London', $csv_content );
 	}
 
 	/**
@@ -204,12 +204,12 @@ class DataExporterTest extends TestCase {
 		// Should be valid XML
 		$this->assertStringStartsWith( '<?xml version="1.0" encoding="UTF-8"?>', $xml_content );
 		
-		// Should contain our data
-		$this->assertStringContains( '<export', $xml_content );
-		$this->assertStringContains( '<records>', $xml_content );
-		$this->assertStringContains( '<record', $xml_content );
-		$this->assertStringContains( 'John', $xml_content );
-		$this->assertStringContains( '30', $xml_content );
+                // Should contain our data
+                $this->assertStringContainsString( '<export', $xml_content );
+                $this->assertStringContainsString( '<records>', $xml_content );
+                $this->assertStringContainsString( '<record', $xml_content );
+                $this->assertStringContainsString( 'John', $xml_content );
+                $this->assertStringContainsString( '30', $xml_content );
 	}
 
 	/**
@@ -311,9 +311,9 @@ class DataExporterTest extends TestCase {
 		$token = 'test_token_123';
 		$url = $method->invoke( null, $token );
 
-		$this->assertStringContains( 'admin-ajax.php', $url );
-		$this->assertStringContains( 'action=fp_download_export', $url );
-		$this->assertStringContains( 'token=' . $token, $url );
+                $this->assertStringContainsString( 'admin-ajax.php', $url );
+                $this->assertStringContainsString( 'action=fp_download_export', $url );
+                $this->assertStringContainsString( 'token=' . $token, $url );
 	}
 
 	/**

--- a/tests/MetricsAggregatorTest.php
+++ b/tests/MetricsAggregatorTest.php
@@ -29,8 +29,9 @@ class MetricsAggregatorTest extends TestCase {
 		parent::setUp();
 
 		// Create mock wpdb
-		$this->wpdb_mock = $this->createMock( stdClass::class );
-		$this->wpdb_mock->prefix = 'wp_';
+                $this->wpdb_mock = $this->createMock( stdClass::class );
+                $this->wpdb_mock->prefix = 'wp_';
+                $this->wpdb_mock->method( 'prepare' )->willReturnArgument( 0 );
 
 		// Set global wpdb
 		global $wpdb;

--- a/tests/MetricsCacheTest.php
+++ b/tests/MetricsCacheTest.php
@@ -28,9 +28,10 @@ class MetricsCacheTest extends TestCase {
 		parent::setUp();
 		
 		// Create mock wpdb object
-		$this->wpdb_mock = $this->createMock( stdClass::class );
-		$this->wpdb_mock->prefix = 'wp_';
-		$this->wpdb_mock->insert_id = 1;
+                $this->wpdb_mock = $this->createMock( stdClass::class );
+                $this->wpdb_mock->prefix = 'wp_';
+                $this->wpdb_mock->insert_id = 1;
+                $this->wpdb_mock->method( 'prepare' )->willReturnArgument( 0 );
 		
 		// Set global $wpdb for tests
 		global $wpdb;

--- a/tests/UTMCampaignTest.php
+++ b/tests/UTMCampaignTest.php
@@ -22,9 +22,10 @@ class UTMCampaignTest extends TestCase {
 		parent::setUp();
 		
 		// Mock WordPress globals and functions
-		global $wpdb;
-		$wpdb = $this->createMock( stdClass::class );
-		$wpdb->prefix = 'wp_';
+                global $wpdb;
+                $wpdb = $this->createMock( stdClass::class );
+                $wpdb->prefix = 'wp_';
+                $wpdb->method( 'prepare' )->willReturnArgument( 0 );
 
 		// Mock WordPress functions
 		if ( ! function_exists( 'sanitize_text_field' ) ) {

--- a/tests/UTMCampaignsTableTest.php
+++ b/tests/UTMCampaignsTableTest.php
@@ -22,9 +22,10 @@ class UTMCampaignsTableTest extends TestCase {
 		parent::setUp();
 		
 		// Mock WordPress globals and functions
-		global $wpdb;
-		$wpdb = $this->createMock( stdClass::class );
-		$wpdb->prefix = 'wp_';
+                global $wpdb;
+                $wpdb = $this->createMock( stdClass::class );
+                $wpdb->prefix = 'wp_';
+                $wpdb->method( 'prepare' )->willReturnArgument( 0 );
 		
 		// Mock WordPress functions
 		if ( ! function_exists( 'dbDelta' ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,12 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 	require_once '/tmp/wordpress-tests-lib/includes/bootstrap.php';
 } else {
-	// Create minimal WordPress environment for testing
-	if ( ! defined( 'WPINC' ) ) {
-		define( 'WPINC', 'wp-includes' );
-	}
-	
-	// Mock WordPress functions for testing
+        // Create minimal WordPress environment for testing
+        if ( ! defined( 'WPINC' ) ) {
+                define( 'WPINC', 'wp-includes' );
+        }
+
+        // Simple in-memory options store for option-related functions.
+        global $wp_options;
+        $wp_options = [];
+
+        // Mock WordPress functions for testing
 	if ( ! function_exists( 'wp_parse_args' ) ) {
 		function wp_parse_args( $args, $defaults = '' ) {
 			if ( is_object( $args ) ) {
@@ -199,15 +203,15 @@ if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 		}
 	}
 
-	if ( ! function_exists( 'get_option' ) ) {
-		function get_option( $option, $default = false ) {
-			global $wp_mock_functions;
-			if ( isset( $wp_mock_functions['get_option'] ) ) {
-				return $wp_mock_functions['get_option']( $option, $default );
-			}
-			return $default;
-		}
-	}
+        if ( ! function_exists( 'get_option' ) ) {
+                function get_option( $option, $default = false ) {
+                        global $wp_mock_functions, $wp_options;
+                        if ( isset( $wp_mock_functions['get_option'] ) ) {
+                                return $wp_mock_functions['get_option']( $option, $default );
+                        }
+                        return $wp_options[ $option ] ?? $default;
+                }
+        }
 
 	if ( ! function_exists( 'get_permalink' ) ) {
 		function get_permalink( $post = 0 ) {
@@ -404,15 +408,87 @@ if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 		}
 	}
 
-	if ( ! function_exists( 'update_option' ) ) {
-		function update_option( $option, $value, $autoload = null ) {
-			global $wp_mock_functions;
-			if ( isset( $wp_mock_functions['update_option'] ) ) {
-				return $wp_mock_functions['update_option']( $option, $value );
-			}
-			return true;
-		}
-	}
+        if ( ! function_exists( 'update_option' ) ) {
+                function update_option( $option, $value, $autoload = null ) {
+                        global $wp_mock_functions, $wp_options;
+                        if ( isset( $wp_mock_functions['update_option'] ) ) {
+                                return $wp_mock_functions['update_option']( $option, $value );
+                        }
+                        $wp_options[ $option ] = $value;
+                        return true;
+                }
+        }
+
+        if ( ! function_exists( 'delete_option' ) ) {
+                function delete_option( $option ) {
+                        global $wp_mock_functions, $wp_options;
+                        if ( isset( $wp_mock_functions['delete_option'] ) ) {
+                                return $wp_mock_functions['delete_option']( $option );
+                        }
+                        unset( $wp_options[ $option ] );
+                        return true;
+                }
+        }
+
+        if ( ! function_exists( 'sanitize_textarea_field' ) ) {
+                function sanitize_textarea_field( $str ) {
+                        return trim( strip_tags( $str ) );
+                }
+        }
+
+        if ( ! function_exists( 'wp_using_ext_object_cache' ) ) {
+                function wp_using_ext_object_cache() {
+                        return false;
+                }
+        }
+
+        if ( ! function_exists( 'is_category' ) ) {
+                function is_category() {
+                        return false;
+                }
+        }
+
+        if ( ! function_exists( 'is_tag' ) ) {
+                function is_tag() {
+                        return false;
+                }
+        }
+
+        if ( ! function_exists( 'is_tax' ) ) {
+                function is_tax() {
+                        return false;
+                }
+        }
+
+        if ( ! function_exists( 'is_single' ) ) {
+                function is_single() {
+                        return false;
+                }
+        }
+
+        if ( ! function_exists( 'is_page' ) ) {
+                function is_page() {
+                        return false;
+                }
+        }
+
+        if ( ! function_exists( 'is_author' ) ) {
+                function is_author() {
+                        return false;
+                }
+        }
+
+        if ( ! function_exists( 'is_archive' ) ) {
+                function is_archive() {
+                        return false;
+                }
+        }
+
+        if ( ! function_exists( 'wp_next_scheduled' ) ) {
+                function wp_next_scheduled( $hook ) {
+                        return false;
+                }
+        }
 
 	// Schema generator and hooks functions
 	if ( ! function_exists( 'apply_filters' ) ) {
@@ -570,11 +646,84 @@ if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 		}
 	}
 
-	// Mock global $wpdb for testing
-	global $wpdb;
-	$wpdb = new stdClass();
-	$wpdb->prefix = 'wp_';
+        // Mock global $wpdb for testing with minimal methods used across the test suite.
+        class WPDB_Mock {
+                /**
+                 * Table prefix.
+                 *
+                 * @var string
+                 */
+                public $prefix = 'wp_';
+
+                /**
+                 * ID of the last inserted row.
+                 *
+                 * @var int
+                 */
+                public $insert_id = 0;
+
+                /**
+                 * Simple query preparer that performs basic sprintf replacement.
+                 *
+                 * @param string $query SQL query with placeholders.
+                 * @param mixed  ...$args Values to substitute into the query.
+                 * @return string Prepared query.
+                 */
+                public function prepare( $query, ...$args ) {
+                        if ( empty( $args ) ) {
+                                return $query;
+                        }
+                        $args = array_map(
+                                function ( $arg ) {
+                                        return is_numeric( $arg ) ? $arg : "'" . $arg . "'";
+                                },
+                                $args
+                        );
+                        // Replace WordPress style placeholders (%s, %d) using vsprintf.
+                        return vsprintf( $query, $args );
+                }
+
+                public function get_results( $query ) { // phpcs:ignore WordPress.DB
+                        return [];
+                }
+
+                public function get_var( $query ) { // phpcs:ignore WordPress.DB
+                        return null;
+                }
+
+                public function get_row( $query ) { // phpcs:ignore WordPress.DB
+                        return null;
+                }
+
+                public function get_col( $query ) { // phpcs:ignore WordPress.DB
+                        return [];
+                }
+
+                public function get_charset_collate() { // phpcs:ignore WordPress.DB
+                        return '';
+                }
+
+                public function query( $query ) { // phpcs:ignore WordPress.DB
+                        return 0;
+                }
+
+                public function insert( $table, $data ) { // phpcs:ignore WordPress.DB
+                        $this->insert_id++;
+                        return $this->insert_id;
+                }
+
+                public function update( $table, $data, $where ) { // phpcs:ignore WordPress.DB
+                        return 1;
+                }
+
+                public function delete( $table, $where ) { // phpcs:ignore WordPress.DB
+                        return 1;
+                }
+        }
+
+        global $wpdb;
+        $wpdb = new WPDB_Mock();
 }
 
-// Load the plugin's autoloader.
+// Load the plugin's autoloader and initialization.
 require_once dirname( __DIR__ ) . '/fp-digital-marketing-suite.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -675,7 +675,7 @@ if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
                         }
                         $args = array_map(
                                 function ( $arg ) {
-                                        return is_numeric( $arg ) ? $arg : "'" . $arg . "'";
+                                        return is_numeric( $arg ) ? $arg : "'" . addslashes( $arg ) . "'";
                                 },
                                 $args
                         );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -707,9 +707,7 @@ if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
                         return 0;
                 }
 
-                public function insert( $table, $data ) { // phpcs:ignore WordPress.DB
-                        $this->insert_id++;
-                        return $this->insert_id;
+                        return 1;
                 }
 
                 public function update( $table, $data, $where ) { // phpcs:ignore WordPress.DB


### PR DESCRIPTION
## Summary
- add in-memory option storage and stub more WordPress conditional helpers in test bootstrap
- extend `WPDB_Mock` with insert tracking and additional query helpers
- update DataExporter tests to use `assertStringContainsString`

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Tests: 323, Assertions: 939, Errors: 99, Failures: 43)*

------
https://chatgpt.com/codex/tasks/task_e_68b98c0e31b8832fa51dd8ce884740d4