### PR TITLE
Use add_query_arg for export download URL

### DIFF
--- a/src/Helpers/DataExporter.php
+++ b/src/Helpers/DataExporter.php
@@ -688,9 +688,15 @@ class DataExporter {
 	 * @param string $token Export token
 	 * @return string Download URL
 	 */
-	private static function get_download_url( string $token ): string {
-		return admin_url( 'admin-ajax.php?action=fp_download_export&token=' . $token );
-	}
+       private static function get_download_url( string $token ): string {
+               return add_query_arg(
+                       [
+                               'action' => 'fp_download_export',
+                               'token'  => $token,
+                       ],
+                       admin_url( 'admin-ajax.php' )
+               );
+       }
 
 	/**
 	 * Handle export download request

--- a/tests/DataExporterTest.php
+++ b/tests/DataExporterTest.php
@@ -46,13 +46,19 @@ class DataExporterTest extends TestCase {
 			}
 		}
 
-		if ( ! function_exists( 'admin_url' ) ) {
-			function admin_url( $path ) {
-				return 'http://example.com/wp-admin/' . $path;
-			}
-		}
+                if ( ! function_exists( 'admin_url' ) ) {
+                        function admin_url( $path ) {
+                                return 'http://example.com/wp-admin/' . $path;
+                        }
+                }
 
-		if ( ! function_exists( 'wp_upload_dir' ) ) {
+                if ( ! function_exists( 'add_query_arg' ) ) {
+                        function add_query_arg( $args, $url ) {
+                                return $url . ( strpos( $url, '?' ) === false ? '?' : '&' ) . http_build_query( $args );
+                        }
+                }
+
+                if ( ! function_exists( 'wp_upload_dir' ) ) {
 			function wp_upload_dir() {
 				return [
 					'basedir' => '/tmp',


### PR DESCRIPTION
## Summary
- Simplify export download link generation using `add_query_arg`
- Mock `add_query_arg` in tests for download URL verification

## Testing
- `composer test` *(fails: Tests: 367, Assertions: 1030, Errors: 111, Failures: 40)*
- `./vendor/bin/phpunit tests/DataExporterTest.php` *(fails: DataExporterTest::test_settings_export_data)*
- `php -r 'require "src/Helpers/DataExporter.php"; function admin_url($path=""){return "http://example.com/wp-admin/".$path;} function add_query_arg($args,$url){return $url.(strpos($url,"?")===false?"?":"&").http_build_query($args);} $ref=new ReflectionClass("FP\\DigitalMarketing\\Helpers\\DataExporter"); $m=$ref->getMethod("get_download_url"); $m->setAccessible(true); echo $m->invoke(null,"abc123"), PHP_EOL;'`

------
https://chatgpt.com/codex/tasks/task_e_68c77bc76d18832f861e3e43403a93bf