### PR TITLE
Sanitize segmentation admin query parameters

### DIFF
--- a/src/Admin/SegmentationAdmin.php
+++ b/src/Admin/SegmentationAdmin.php
@@ -163,8 +163,8 @@ class SegmentationAdmin {
 	 * @return void
 	 */
 	public function render_admin_page(): void {
-		$action = $_GET['action'] ?? 'list';
-		$segment_id = isset( $_GET['segment_id'] ) ? (int) $_GET['segment_id'] : 0;
+		$action = sanitize_key( $_GET['action'] ?? 'list' );
+		$segment_id = isset( $_GET['segment_id'] ) ? intval( $_GET['segment_id'] ) : 0;
 
 		echo '<div class="wrap">';
 		echo '<h1>' . esc_html__( 'Segmentazione Audience', 'fp-digital-marketing' ) . '</h1>';


### PR DESCRIPTION
## Summary
- Sanitize `action` and `segment_id` query vars in Segmentation admin page to harden request handling

## Testing
- `composer test` *(fails: Tests: 367, Assertions: 1030, Errors: 111, Failures: 40)*
- `composer phpcs` *(fails: returned error code 2)*
- `composer phpstan` *(fails: allowed memory exhausted)*

------
https://chatgpt.com/codex/tasks/task_e_68c77fbb6d2c832fab47d2bb11a2f4fe