### PR TITLE
Secure segment deletion with nonce validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Added nonce validation for audience segment deletion to prevent unauthorized requests.
+
 ### Planned
 - WordPress.org plugin directory submission
 - Additional translation languages

--- a/src/Admin/SegmentationAdmin.php
+++ b/src/Admin/SegmentationAdmin.php
@@ -264,11 +264,11 @@ class SegmentationAdmin {
 			echo '<td>';
 			echo '<a href="' . esc_url( $view_url ) . '" class="button button-small">' . esc_html__( 'Visualizza', 'fp-digital-marketing' ) . '</a> ';
 			echo '<a href="' . esc_url( $edit_url ) . '" class="button button-small">' . esc_html__( 'Modifica', 'fp-digital-marketing' ) . '</a> ';
-			echo '<button class="button button-small evaluate-segment" data-segment-id="' . esc_attr( $segment['id'] ) . '">' . esc_html__( 'Valuta', 'fp-digital-marketing' ) . '</button> ';
-			echo '<a href="' . esc_url( wp_nonce_url( $delete_url, self::NONCE_ACTION, 'fp_segmentation_nonce' ) ) . '" class="button button-small button-link-delete" onclick="return confirm(\'' . esc_js( __( 'Sei sicuro di voler eliminare questo segmento?', 'fp-digital-marketing' ) ) . '\')">' . esc_html__( 'Elimina', 'fp-digital-marketing' ) . '</a>';
-			echo '</td>';
-			echo '</tr>';
-		}
+                       echo '<button class="button button-small evaluate-segment" data-segment-id="' . esc_attr( $segment['id'] ) . '">' . esc_html__( 'Valuta', 'fp-digital-marketing' ) . '</button> ';
+                       echo '<a href="' . esc_url( wp_nonce_url( $delete_url, 'fp_delete_segment', 'segment_nonce' ) ) . '" class="button button-small button-link-delete" onclick="return confirm(\'' . esc_js( __( 'Sei sicuro di voler eliminare questo segmento?', 'fp-digital-marketing' ) ) . '\')">' . esc_html__( 'Elimina', 'fp-digital-marketing' ) . '</a>';
+                       echo '</td>';
+                       echo '</tr>';
+               }
 
 		echo '</tbody>';
 		echo '</table>';
@@ -534,28 +534,33 @@ class SegmentationAdmin {
 	 *
 	 * @return void
 	 */
-	private function handle_delete_segment(): void {
-                if ( ! isset( $_GET['segment_id'] ) ) {
-                        wp_redirect( add_query_arg( [ 'message' => 'error' ], remove_query_arg( [ 'action', 'segment_id' ] ) ) );
-                        exit;
-                }
+       private function handle_delete_segment(): void {
+               if ( ! wp_verify_nonce( $_GET['segment_nonce'] ?? '', 'fp_delete_segment' ) ) {
+                       wp_redirect( add_query_arg( [ 'message' => 'error' ], remove_query_arg( [ 'action', 'segment_id', 'segment_nonce' ] ) ) );
+                       exit;
+               }
 
-                $segment_id = (int) $_GET['segment_id'];
-                $segment = AudienceSegment::load_by_id( $segment_id );
+               if ( ! isset( $_GET['segment_id'] ) ) {
+                       wp_redirect( add_query_arg( [ 'message' => 'error' ], remove_query_arg( [ 'action', 'segment_id', 'segment_nonce' ] ) ) );
+                       exit;
+               }
 
-		if ( ! $segment ) {
-			wp_redirect( add_query_arg( [ 'message' => 'not_found' ], remove_query_arg( [ 'action', 'segment_id' ] ) ) );
-			exit;
-		}
+               $segment_id = (int) $_GET['segment_id'];
+               $segment = AudienceSegment::load_by_id( $segment_id );
 
-		if ( $segment->delete() ) {
-			wp_redirect( add_query_arg( [ 'message' => 'deleted' ], remove_query_arg( [ 'action', 'segment_id' ] ) ) );
-			exit;
-		} else {
-			wp_redirect( add_query_arg( [ 'message' => 'error' ], remove_query_arg( [ 'action', 'segment_id' ] ) ) );
-			exit;
-		}
-	}
+               if ( ! $segment ) {
+                       wp_redirect( add_query_arg( [ 'message' => 'not_found' ], remove_query_arg( [ 'action', 'segment_id', 'segment_nonce' ] ) ) );
+                       exit;
+               }
+
+               if ( $segment->delete() ) {
+                       wp_redirect( add_query_arg( [ 'message' => 'deleted' ], remove_query_arg( [ 'action', 'segment_id', 'segment_nonce' ] ) ) );
+                       exit;
+               } else {
+                       wp_redirect( add_query_arg( [ 'message' => 'error' ], remove_query_arg( [ 'action', 'segment_id', 'segment_nonce' ] ) ) );
+                       exit;
+               }
+       }
 
 	/**
 	 * Sanitize segment data from form

--- a/tests/SegmentationAdminDeleteTest.php
+++ b/tests/SegmentationAdminDeleteTest.php
@@ -24,6 +24,12 @@ if ( ! function_exists( 'wp_redirect' ) ) {
     }
 }
 
+if ( ! function_exists( 'wp_verify_nonce' ) ) {
+    function wp_verify_nonce( $nonce, $action ) {
+        return $nonce === 'valid' && $action === 'fp_delete_segment';
+    }
+}
+
 if ( ! defined( 'ARRAY_A' ) ) {
     define( 'ARRAY_A', 'ARRAY_A' );
 }
@@ -49,6 +55,7 @@ class SegmentationAdminDeleteTest extends TestCase {
 
     public function test_delete_without_segment_id_redirects_error(): void {
         $admin = new SegmentationAdmin();
+        $_GET['segment_nonce'] = 'valid';
         try {
             $this->invoke_delete($admin);
             $this->fail('Expected redirect');
@@ -74,6 +81,7 @@ class SegmentationAdminDeleteTest extends TestCase {
         ] ];
 
         $_GET['segment_id'] = 5;
+        $_GET['segment_nonce'] = 'valid';
         $admin = new SegmentationAdmin();
 
         try {


### PR DESCRIPTION
## Summary
- Protect segment deletion link with dedicated nonce parameter
- Verify `segment_nonce` before deleting and redirect on failure
- Cover deletion workflow with updated tests and changelog entry

## Testing
- `./vendor/bin/phpunit tests/SegmentationAdminDeleteTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c780d96910832fb7332a3142a4c94d