### PR TITLE
Ensure admin optimizations script loads wp-util

### DIFF
--- a/src/Helpers/AdminOptimizations.php
+++ b/src/Helpers/AdminOptimizations.php
@@ -60,7 +60,7 @@ class AdminOptimizations {
         wp_enqueue_script(
             'fp-dms-admin-optimizations',
             FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/admin-optimizations.js',
-            [ 'jquery' ],
+            [ 'jquery', 'wp-util' ],
             FP_DIGITAL_MARKETING_VERSION,
             true
         );


### PR DESCRIPTION
## Summary
- add wp-util as a dependency for the admin optimizations script so wp.ajax is available before inline scripts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cad6196020832fbb1b73b7247ddefa