### PR TITLE
Fix drop table queries and improve uninstall cleanup

### DIFF
--- a/src/Database/AlertRulesTable.php
+++ b/src/Database/AlertRulesTable.php
@@ -81,10 +81,10 @@ class AlertRulesTable {
 	public static function drop_table(): bool {
 		global $wpdb;
 
-		$table_name = self::get_table_name();
-		$result = $wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table_name ) );
-		
-		return $result !== false;
+                $table_name = self::get_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
 	}
 
 	/**

--- a/src/Database/AnomalyRulesTable.php
+++ b/src/Database/AnomalyRulesTable.php
@@ -87,10 +87,10 @@ class AnomalyRulesTable {
 	public static function drop_table(): bool {
 		global $wpdb;
 
-		$table_name = self::get_table_name();
-		$result = $wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table_name ) );
-		
-		return $result !== false;
+                $table_name = self::get_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
 	}
 
 	/**

--- a/src/Database/DetectedAnomaliesTable.php
+++ b/src/Database/DetectedAnomaliesTable.php
@@ -87,10 +87,10 @@ class DetectedAnomaliesTable {
 	public static function drop_table(): bool {
 		global $wpdb;
 
-		$table_name = self::get_table_name();
-		$result = $wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table_name ) );
-		
-		return $result !== false;
+                $table_name = self::get_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
 	}
 
 	/**

--- a/src/Database/MetricsCacheTable.php
+++ b/src/Database/MetricsCacheTable.php
@@ -78,10 +78,10 @@ class MetricsCacheTable {
 	public static function drop_table(): bool {
 		global $wpdb;
 
-		$table_name = self::get_table_name();
-		$result = $wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table_name ) );
-		
-		return $result !== false;
+                $table_name = self::get_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -24,7 +24,24 @@ if ( ! current_user_can( 'activate_plugins' ) ) {
  */
 function fp_dms_cleanup_database_tables() {
     global $wpdb;
-    
+
+    $table_classes = array(
+        '\\FP\\DigitalMarketing\\Database\\MetricsCacheTable' => __DIR__ . '/src/Database/MetricsCacheTable.php',
+        '\\FP\\DigitalMarketing\\Database\\AlertRulesTable' => __DIR__ . '/src/Database/AlertRulesTable.php',
+        '\\FP\\DigitalMarketing\\Database\\AnomalyRulesTable' => __DIR__ . '/src/Database/AnomalyRulesTable.php',
+        '\\FP\\DigitalMarketing\\Database\\DetectedAnomaliesTable' => __DIR__ . '/src/Database/DetectedAnomaliesTable.php',
+    );
+
+    foreach ( $table_classes as $class => $path ) {
+        if ( ! class_exists( $class ) && file_exists( $path ) ) {
+            require_once $path;
+        }
+
+        if ( class_exists( $class ) && method_exists( $class, 'drop_table' ) ) {
+            $class::drop_table();
+        }
+    }
+
     // List of custom tables to remove
     $tables = array(
         $wpdb->prefix . 'fp_dms_clients',
@@ -35,10 +52,10 @@ function fp_dms_cleanup_database_tables() {
         $wpdb->prefix . 'fp_dms_alerts',
         $wpdb->prefix . 'fp_dms_performance_metrics'
     );
-    
+
     // Drop each table
     foreach ( $tables as $table ) {
-        $wpdb->query( $wpdb->prepare( "DROP TABLE IF EXISTS %i", $table ) );
+        $wpdb->query( "DROP TABLE IF EXISTS {$table}" );
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the DROP TABLE prepared statements in the metrics/alert/anomaly cache handlers with direct sanitized queries
- load the database table classes during uninstall and reuse their drop_table helpers before issuing fallback DROP TABLE statements

## Testing
- php -l src/Database/MetricsCacheTable.php
- php -l src/Database/AlertRulesTable.php
- php -l src/Database/AnomalyRulesTable.php
- php -l src/Database/DetectedAnomaliesTable.php
- php -l uninstall.php

------
https://chatgpt.com/codex/tasks/task_e_68cb22b102e4832f940c1150df02eca7