### PR TITLE
Fix CSV export field quoting

### DIFF
--- a/src/Admin/ConversionEventsAdmin.php
+++ b/src/Admin/ConversionEventsAdmin.php
@@ -904,14 +904,16 @@ class ConversionEventsAdmin {
 	 * @return string CSV line
 	 */
 	private function array_to_csv_line( array $data ): string {
-		$escaped_data = array_map( function( $field ) {
-			// Escape quotes and wrap in quotes if necessary
-			$field = str_replace( '"', '""', $field );
-			if ( strpos( $field, ',' ) !== false || strpos( $field, '"' ) !== false || strpos( $field, "\n" ) !== false ) {
-				$field = '"' . $field . '"';
-			}
-			return $field;
-		}, $data );
+                $escaped_data = array_map( function( $field ) {
+                        // Escape quotes and wrap in quotes if necessary
+                        $field = (string) $field;
+                        $quote = '"';
+                        $field = str_replace( $quote, $quote . $quote, $field );
+                        if ( strpos( $field, ',' ) !== false || strpos( $field, $quote ) !== false || strpos( $field, "\n" ) !== false ) {
+                                $field = $quote . $field . $quote;
+                        }
+                        return $field;
+                }, $data );
 		
 		return implode( ',', $escaped_data );
 	}


### PR DESCRIPTION
## Summary
- cast CSV fields to string before escaping
- centralize double-quote escaping so CSV quoting uses the real character

## Testing
- php -l src/Admin/ConversionEventsAdmin.php

------
https://chatgpt.com/codex/tasks/task_e_68cb24107144832fb4e103699214b22d