### PR TITLE
Add user-specific filtering for conversion events

### DIFF
--- a/src/Database/ConversionEventsTable.php
+++ b/src/Database/ConversionEventsTable.php
@@ -197,6 +197,28 @@ class ConversionEventsTable {
 			}
 		}
 
+		if ( isset( $criteria['user_id'] ) ) {
+			if ( is_array( $criteria['user_id'] ) ) {
+				$user_ids = array_map(
+					static function ( $user_id ) {
+						return sanitize_text_field( (string) $user_id );
+					},
+					$criteria['user_id']
+				);
+
+				if ( empty( $user_ids ) ) {
+					$where_clauses[] = '1=0';
+				} else {
+					$placeholders = implode( ',', array_fill( 0, count( $user_ids ), '%s' ) );
+					$where_clauses[] = "user_id IN ($placeholders)";
+					$where_values = array_merge( $where_values, $user_ids );
+				}
+			} else {
+				$where_clauses[] = 'user_id = %s';
+				$where_values[] = sanitize_text_field( (string) $criteria['user_id'] );
+			}
+		}
+
 		if ( isset( $criteria['source'] ) ) {
 			if ( is_array( $criteria['source'] ) ) {
 				$placeholders = implode( ',', array_fill( 0, count( $criteria['source'] ), '%s' ) );
@@ -276,6 +298,28 @@ class ConversionEventsTable {
 			} else {
 				$where_clauses[] = 'event_type = %s';
 				$where_values[] = $criteria['event_type'];
+			}
+		}
+
+		if ( isset( $criteria['user_id'] ) ) {
+			if ( is_array( $criteria['user_id'] ) ) {
+				$user_ids = array_map(
+					static function ( $user_id ) {
+						return sanitize_text_field( (string) $user_id );
+					},
+					$criteria['user_id']
+				);
+
+				if ( empty( $user_ids ) ) {
+					$where_clauses[] = '1=0';
+				} else {
+					$placeholders = implode( ',', array_fill( 0, count( $user_ids ), '%s' ) );
+					$where_clauses[] = "user_id IN ($placeholders)";
+					$where_values = array_merge( $where_values, $user_ids );
+				}
+			} else {
+				$where_clauses[] = 'user_id = %s';
+				$where_values[] = sanitize_text_field( (string) $criteria['user_id'] );
 			}
 		}
 

--- a/tests/AudienceSegmentationTest.php
+++ b/tests/AudienceSegmentationTest.php
@@ -10,6 +10,9 @@ require_once __DIR__ . '/bootstrap.php';
 
 use FP\DigitalMarketing\Models\AudienceSegment;
 use FP\DigitalMarketing\Database\AudienceSegmentTable;
+use FP\DigitalMarketing\Database\ConversionEventsTable;
+use FP\DigitalMarketing\Helpers\ConversionEventManager;
+use FP\DigitalMarketing\Helpers\ConversionEventRegistry;
 use FP\DigitalMarketing\Helpers\SegmentationEngine;
 use PHPUnit\Framework\TestCase;
 
@@ -218,5 +221,115 @@ class AudienceSegmentationTest extends TestCase {
 
 		$segment->update_evaluation_timestamp();
 		$this->assertNotNull( $segment->get_last_evaluated_at() );
+	}
+
+	/**
+	 * Test segment evaluation only considers events for the evaluated user.
+	 */
+	public function test_segment_evaluation_filters_events_by_user(): void {
+		$client_id = 4321;
+
+		ConversionEventsTable::create_table();
+
+		try {
+			$segment = new AudienceSegment( [
+				'name' => 'High Value Buyers',
+				'client_id' => $client_id,
+				'is_active' => true,
+				'rules' => [
+					'logic' => 'AND',
+					'conditions' => [
+						[
+							'type' => 'event',
+							'field' => ConversionEventRegistry::EVENT_PURCHASE,
+							'operator' => 'greater_than',
+							'value' => '1',
+						],
+					],
+				],
+			] );
+
+			$base_event = [
+				'event_type' => 'purchase',
+				'value' => 125.0,
+				'currency' => 'EUR',
+				'ip_address' => '203.0.113.10',
+			];
+
+			ConversionEventManager::ingest_event(
+				'google_analytics_4',
+				array_merge(
+					$base_event,
+					[
+						'user_id' => 'segment-user-a',
+						'timestamp' => '2024-01-03 09:00:00',
+					]
+				),
+				$client_id
+			);
+
+			ConversionEventManager::ingest_event(
+				'google_analytics_4',
+				array_merge(
+					$base_event,
+					[
+						'user_id' => 'segment-user-a',
+						'timestamp' => '2024-01-03 09:10:00',
+					]
+				),
+				$client_id
+			);
+
+			ConversionEventManager::ingest_event(
+				'google_analytics_4',
+				array_merge(
+					$base_event,
+					[
+						'user_id' => 'segment-user-b',
+						'timestamp' => '2024-01-03 09:00:30',
+					]
+				),
+				$client_id
+			);
+
+			$user_a_events = ConversionEventsTable::get_events(
+				[
+					'client_id' => $client_id,
+					'user_id' => 'segment-user-a',
+				],
+				10,
+				0
+			);
+			$this->assertCount( 2, $user_a_events );
+
+			$user_b_events = ConversionEventsTable::get_events(
+				[
+					'client_id' => $client_id,
+					'user_id' => 'segment-user-b',
+				],
+				10,
+				0
+			);
+			$this->assertCount( 1, $user_b_events );
+			$this->assertEquals( 0, $user_b_events[0]['is_duplicate'] );
+			$this->assertEquals(
+				1,
+				ConversionEventsTable::get_events_count(
+					[
+						'client_id' => $client_id,
+						'user_id' => 'segment-user-b',
+					]
+				)
+			);
+
+			$this->assertTrue(
+				SegmentationEngine::evaluate_user_against_segment( 'segment-user-a', $segment )
+			);
+			$this->assertFalse(
+				SegmentationEngine::evaluate_user_against_segment( 'segment-user-b', $segment )
+			);
+		} finally {
+			ConversionEventsTable::drop_table();
+		}
 	}
 }

--- a/tests/ConversionEventsTest.php
+++ b/tests/ConversionEventsTest.php
@@ -251,6 +251,82 @@ class ConversionEventsTest extends TestCase {
 	}
 
 	/**
+	 * Ensure events with different user IDs are not marked as duplicates.
+	 */
+	public function test_events_with_different_user_ids_are_not_marked_as_duplicates(): void {
+		$client_id = 654;
+		$source = 'facebook_ads';
+
+		$base_event = [
+			'event_type' => 'purchase',
+			'value' => 199.99,
+			'currency' => 'EUR',
+			'ip_address' => '198.51.100.10',
+			'timestamp' => '2024-01-05 12:00:00',
+		];
+
+		$first_event = ConversionEventManager::ingest_event(
+			$source,
+			array_merge(
+				$base_event,
+				[
+					'user_id' => 'duplicate-user-a',
+				]
+			),
+			$client_id
+		);
+
+		$this->assertInstanceOf( ConversionEvent::class, $first_event );
+		$this->assertFalse( $first_event->is_duplicate() );
+
+		$second_event = ConversionEventManager::ingest_event(
+			$source,
+			array_merge(
+				$base_event,
+				[
+					'user_id' => 'duplicate-user-b',
+					'timestamp' => '2024-01-05 12:00:30',
+				]
+			),
+			$client_id
+		);
+
+		$this->assertInstanceOf( ConversionEvent::class, $second_event );
+		$this->assertFalse( $second_event->is_duplicate() );
+
+		$user_a_events = ConversionEventsTable::get_events(
+			[
+				'client_id' => $client_id,
+				'user_id' => 'duplicate-user-a',
+			],
+			10,
+			0
+		);
+		$this->assertCount( 1, $user_a_events );
+		$this->assertSame( 'duplicate-user-a', $user_a_events[0]['user_id'] );
+
+		$user_b_events = ConversionEventsTable::get_events(
+			[
+				'client_id' => $client_id,
+				'user_id' => 'duplicate-user-b',
+			],
+			10,
+			0
+		);
+		$this->assertCount( 1, $user_b_events );
+		$this->assertSame( 'duplicate-user-b', $user_b_events[0]['user_id'] );
+		$this->assertEquals(
+			1,
+			ConversionEventsTable::get_events_count(
+				[
+					'client_id' => $client_id,
+					'user_id' => 'duplicate-user-b',
+				]
+			)
+		);
+	}
+
+	/**
 	 * Test bulk event ingestion
 	 */
 	public function test_bulk_ingestion(): void {


### PR DESCRIPTION
## Summary
- sanitize and bind user_id filters in conversion event queries, with support for array criteria
- add regression coverage ensuring deduplication treats different users as unique events
- extend segmentation tests to confirm user-level filtering of conversion data

## Testing
- ./vendor/bin/phpunit --configuration phpunit.xml *(fails: existing suite warnings/errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cb29d211f4832fb4c32029b565a0d1