### PR TITLE
Add MenuManager guard to legacy admin menus

### DIFF
--- a/src/Admin/AnomalyDetectionAdmin.php
+++ b/src/Admin/AnomalyDetectionAdmin.php
@@ -15,6 +15,7 @@ use FP\DigitalMarketing\Helpers\AlertEngine;
 use FP\DigitalMarketing\Helpers\AnomalyDetector;
 use FP\DigitalMarketing\Helpers\MetricsSchema;
 use FP\DigitalMarketing\Helpers\Capabilities;
+use FP\DigitalMarketing\Admin\MenuManager;
 
 /**
  * AnomalyDetectionAdmin class for managing anomaly detection interface
@@ -47,13 +48,17 @@ class AnomalyDetectionAdmin {
 
 	/**
 	 * Add admin menu
-	 *
-	 * @return void
-	 */
-	public function add_admin_menu(): void {
-		add_submenu_page(
-			'fp-digital-marketing-dashboard',
-			__( 'Rilevazione Anomalie', 'fp-digital-marketing' ),
+        *
+         * @return void
+         */
+        public function add_admin_menu(): void {
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
+                        return;
+                }
+
+                add_submenu_page(
+                        'fp-digital-marketing-dashboard',
+                        __( 'Rilevazione Anomalie', 'fp-digital-marketing' ),
 			__( '🔍 Rilevazione Anomalie', 'fp-digital-marketing' ),
 			Capabilities::MANAGE_ALERTS,
 			'fp-digital-marketing-anomalies',

--- a/src/Admin/CachePerformance.php
+++ b/src/Admin/CachePerformance.php
@@ -12,6 +12,7 @@ namespace FP\DigitalMarketing\Admin;
 use FP\DigitalMarketing\Helpers\PerformanceCache;
 use FP\DigitalMarketing\Helpers\CacheBenchmark;
 use FP\DigitalMarketing\Helpers\Capabilities;
+use FP\DigitalMarketing\Admin\MenuManager;
 
 /**
  * Cache Performance admin page class
@@ -36,13 +37,17 @@ class CachePerformance {
 
 	/**
 	 * Add admin menu page
-	 *
-	 * @return void
-	 */
-	public function add_admin_menu(): void {
-		add_submenu_page(
-			'fp-digital-marketing-dashboard',
-			__( 'Cache Performance', 'fp-digital-marketing' ),
+        *
+         * @return void
+         */
+        public function add_admin_menu(): void {
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
+                        return;
+                }
+
+                add_submenu_page(
+                        'fp-digital-marketing-dashboard',
+                        __( 'Cache Performance', 'fp-digital-marketing' ),
 			__( '⚡ Cache Performance', 'fp-digital-marketing' ),
 			Capabilities::MANAGE_SETTINGS,
 			self::PAGE_SLUG,

--- a/src/Admin/ConversionEventsAdmin.php
+++ b/src/Admin/ConversionEventsAdmin.php
@@ -14,6 +14,7 @@ use FP\DigitalMarketing\Helpers\ConversionEventRegistry;
 use FP\DigitalMarketing\Models\ConversionEvent;
 use FP\DigitalMarketing\Database\ConversionEventsTable;
 use FP\DigitalMarketing\Helpers\Capabilities;
+use FP\DigitalMarketing\Admin\MenuManager;
 
 /**
  * Conversion Events Admin class
@@ -48,13 +49,17 @@ class ConversionEventsAdmin {
 
 	/**
 	 * Add admin menu
-	 *
-	 * @return void
-	 */
-	public function add_admin_menu(): void {
-		add_submenu_page(
-			'fp-digital-marketing-dashboard',
-			__( 'Eventi Conversione', 'fp-digital-marketing' ),
+        *
+         * @return void
+         */
+        public function add_admin_menu(): void {
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
+                        return;
+                }
+
+                add_submenu_page(
+                        'fp-digital-marketing-dashboard',
+                        __( 'Eventi Conversione', 'fp-digital-marketing' ),
 			__( '🎯 Eventi Conversione', 'fp-digital-marketing' ),
 			Capabilities::MANAGE_CONVERSIONS,
 			self::PAGE_SLUG,

--- a/src/Admin/PlatformConnections.php
+++ b/src/Admin/PlatformConnections.php
@@ -12,6 +12,7 @@ namespace FP\DigitalMarketing\Admin;
 use FP\DigitalMarketing\Helpers\ConnectionManager;
 use FP\DigitalMarketing\Helpers\Capabilities;
 use FP\DigitalMarketing\DataSources\GoogleOAuth;
+use FP\DigitalMarketing\Admin\MenuManager;
 
 /**
  * PlatformConnections class for managing platform integrations
@@ -38,13 +39,17 @@ class PlatformConnections {
 
 	/**
 	 * Add admin menu page
-	 *
-	 * @return void
-	 */
-	public function add_admin_menu(): void {
-		add_submenu_page(
-			'fp-digital-marketing-dashboard',
-			__( 'Connessioni Piattaforme', 'fp-digital-marketing' ),
+        *
+         * @return void
+         */
+        public function add_admin_menu(): void {
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
+                        return;
+                }
+
+                add_submenu_page(
+                        'fp-digital-marketing-dashboard',
+                        __( 'Connessioni Piattaforme', 'fp-digital-marketing' ),
 			__( '🔗 Connessioni', 'fp-digital-marketing' ),
 			Capabilities::MANAGE_SETTINGS,
 			self::PAGE_SLUG,

--- a/src/Admin/SecurityAdmin.php
+++ b/src/Admin/SecurityAdmin.php
@@ -11,6 +11,7 @@ namespace FP\DigitalMarketing\Admin;
 
 use FP\DigitalMarketing\Helpers\Security;
 use FP\DigitalMarketing\Helpers\Capabilities;
+use FP\DigitalMarketing\Admin\MenuManager;
 
 /**
  * Security admin page for monitoring and auditing
@@ -35,13 +36,17 @@ class SecurityAdmin {
 
 	/**
 	 * Add security admin menu
-	 *
-	 * @return void
-	 */
-	public function add_admin_menu(): void {
-		add_submenu_page(
-			'fp-digital-marketing-dashboard',
-			__( 'Security Settings', 'fp-digital-marketing' ),
+        *
+         * @return void
+         */
+        public function add_admin_menu(): void {
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
+                        return;
+                }
+
+                add_submenu_page(
+                        'fp-digital-marketing-dashboard',
+                        __( 'Security Settings', 'fp-digital-marketing' ),
 			__( '🔒 Security', 'fp-digital-marketing' ),
 			Capabilities::MANAGE_SETTINGS,
 			self::PAGE_SLUG,

--- a/src/Admin/SegmentationAdmin.php
+++ b/src/Admin/SegmentationAdmin.php
@@ -15,6 +15,7 @@ use FP\DigitalMarketing\Helpers\SegmentationEngine;
 use FP\DigitalMarketing\Helpers\ConversionEventRegistry;
 use FP\DigitalMarketing\Helpers\Capabilities;
 use FP\DigitalMarketing\PostTypes\ClientePostType;
+use FP\DigitalMarketing\Admin\MenuManager;
 
 /**
  * Segmentation Admin class
@@ -47,13 +48,17 @@ class SegmentationAdmin {
 
 	/**
 	 * Add admin menu
-	 *
-	 * @return void
-	 */
-	public function add_admin_menu(): void {
-		add_submenu_page(
-			'fp-digital-marketing-dashboard',
-			__( 'Segmentazione Audience', 'fp-digital-marketing' ),
+        *
+         * @return void
+         */
+        public function add_admin_menu(): void {
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
+                        return;
+                }
+
+                add_submenu_page(
+                        'fp-digital-marketing-dashboard',
+                        __( 'Segmentazione Audience', 'fp-digital-marketing' ),
 			__( '👥 Segmentazione', 'fp-digital-marketing' ),
 			Capabilities::MANAGE_SEGMENTS,
 			self::PAGE_SLUG,


### PR DESCRIPTION
## Summary
- add MenuManager imports to admin classes that still register their own submenu
- skip legacy submenu registration when the centralized MenuManager is active

## Testing
- not run (environment lacks WordPress runtime)


------
https://chatgpt.com/codex/tasks/task_e_68cbb249cd2c832f87bfc374c5501a37