### PR TITLE
Defer sync scheduling to option update hook

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -136,14 +136,20 @@ class Settings {
 	 */
 	public function init(): void {
 		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
-		add_action( 'admin_init', [ $this, 'register_settings' ] );
-		add_action( 'admin_init', [ $this, 'handle_ga4_oauth_callback' ] );
-		add_action( 'admin_init', [ $this, 'handle_gsc_oauth_callback' ] );
-		add_action( 'wp_ajax_fp_clear_sitemap_cache', [ $this, 'handle_clear_sitemap_cache' ] );
-		add_action( 'wp_ajax_fp_warmup_cache', [ $this, 'handle_cache_warmup' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
-		add_action( 'fp_dms_cache_warmup', [ $this, 'scheduled_cache_warmup' ] );
-	}
+                add_action( 'admin_init', [ $this, 'register_settings' ] );
+                add_action( 'admin_init', [ $this, 'handle_ga4_oauth_callback' ] );
+                add_action( 'admin_init', [ $this, 'handle_gsc_oauth_callback' ] );
+                add_action( 'wp_ajax_fp_clear_sitemap_cache', [ $this, 'handle_clear_sitemap_cache' ] );
+                add_action( 'wp_ajax_fp_warmup_cache', [ $this, 'handle_cache_warmup' ] );
+                add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+                add_action( 'fp_dms_cache_warmup', [ $this, 'scheduled_cache_warmup' ] );
+                add_action(
+                        'update_option_' . self::OPTION_SYNC,
+                        [ $this, 'handle_sync_settings_update' ],
+                        10,
+                        3
+                );
+        }
 
 	/**
 	 * Add admin menu page
@@ -1155,10 +1161,10 @@ class Settings {
 	 * @param mixed $input The input data.
 	 * @return array Sanitized sync settings array.
 	 */
-	public function sanitize_sync_settings( $input ): array {
-		if ( ! is_array( $input ) ) {
-			return [];
-		}
+        public function sanitize_sync_settings( $input ): array {
+                if ( ! is_array( $input ) ) {
+                        return [];
+                }
 
 		$sanitized = [];
 		
@@ -1173,22 +1179,42 @@ class Settings {
 
 		// If sync settings changed, reschedule the sync
 		$current_settings = get_option( self::OPTION_SYNC, [] );
-		if ( $sanitized !== $current_settings ) {
-			// Unschedule and reschedule with new settings
-			SyncEngine::unschedule_sync();
-			if ( $sanitized['enable_sync'] ) {
-				SyncEngine::schedule_sync();
-			}
-		}
+                if ( $sanitized !== $current_settings ) {
+                        // Unschedule existing events; rescheduling is handled after the option update.
+                        SyncEngine::unschedule_sync();
+                }
 
-		return $sanitized;
-	}
+                return $sanitized;
+        }
 
-	/**
-	 * Get sync settings
-	 *
-	 * @return array The sync settings array.
-	 */
+        /**
+         * Handle sync settings updates after they are saved.
+         *
+         * @param mixed  $old_value Previous option value.
+         * @param mixed  $value     New option value.
+         * @param string $option    Option name.
+         * @return void
+         */
+        public function handle_sync_settings_update( $old_value, $value, string $option ): void {
+                if ( ! is_array( $value ) ) {
+                        SyncEngine::unschedule_sync();
+                        return;
+                }
+
+                SyncEngine::unschedule_sync();
+
+                if ( empty( $value['enable_sync'] ) ) {
+                        return;
+                }
+
+                SyncEngine::schedule_sync_with_settings( $value );
+        }
+
+        /**
+         * Get sync settings
+         *
+         * @return array The sync settings array.
+         */
 	public function get_sync_settings(): array {
 		return get_option( self::OPTION_SYNC, [] );
 	}

--- a/src/Helpers/SyncEngine.php
+++ b/src/Helpers/SyncEngine.php
@@ -73,15 +73,37 @@ class SyncEngine {
          * @return void
          */
         public static function schedule_sync(): void {
-                if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-                        $frequency = self::get_sync_frequency();
+                $settings = get_option( 'fp_digital_marketing_sync_settings', [] );
 
-                        wp_schedule_event(
-                                time() + $frequency['interval'],
-                                $frequency['slug'],
-                                self::CRON_HOOK
-                        );
+                if ( ! is_array( $settings ) ) {
+                        $settings = [];
                 }
+
+                self::schedule_sync_with_settings( $settings );
+        }
+
+        /**
+         * Schedule sync using provided settings.
+         *
+         * @param array $settings Sync settings array.
+         * @return void
+         */
+        public static function schedule_sync_with_settings( array $settings ): void {
+                if ( empty( $settings['enable_sync'] ) ) {
+                        return;
+                }
+
+                if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+                        return;
+                }
+
+                $frequency = self::get_sync_frequency( $settings );
+
+                wp_schedule_event(
+                        time() + $frequency['interval'],
+                        $frequency['slug'],
+                        self::CRON_HOOK
+                );
         }
 
         /**
@@ -447,10 +469,18 @@ class SyncEngine {
         /**
          * Get sync frequency definition from settings.
          *
+         * @param array|null $settings Optional settings array to evaluate.
          * @return array{interval:int, slug:string} Sync frequency definition.
          */
-        public static function get_sync_frequency(): array {
-                $settings      = get_option( 'fp_digital_marketing_sync_settings', [] );
+        public static function get_sync_frequency( ?array $settings = null ): array {
+                if ( null === $settings ) {
+                        $settings = get_option( 'fp_digital_marketing_sync_settings', [] );
+                }
+
+                if ( ! is_array( $settings ) ) {
+                        $settings = [];
+                }
+
                 $frequency_key = $settings['sync_frequency'] ?? self::DEFAULT_SYNC_OPTION;
 
                 if ( isset( self::SYNC_FREQUENCIES[ $frequency_key ] ) ) {


### PR DESCRIPTION
## Summary
- add an update_option hook to handle sync rescheduling with the persisted settings payload
- introduce SyncEngine::schedule_sync_with_settings() and delegate scheduling to it so frequency changes apply immediately

## Testing
- ./vendor/bin/phpunit *(fails: existing suite depends on full WordPress stubs and reports numerous deprecations/failures)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb3112a20832f97c0c724247dff6d