### PR TITLE
Use cache stats for daily digest performance metric

### DIFF
--- a/src/Helpers/EmailNotifications.php
+++ b/src/Helpers/EmailNotifications.php
@@ -653,13 +653,15 @@ class EmailNotifications {
 		}
 
 		// Gather daily statistics
+		$cache_stats = PerformanceCache::get_cache_stats();
+
 		$digest_data = [
 			'report_type' => 'daily_digest',
 			'date' => current_time( 'Y-m-d' ),
 			'summary' => __( 'Here is your daily summary from FP Digital Marketing Suite.', 'fp-digital-marketing' ),
 			'metrics' => [
 				'Cache Performance' => [
-					'current' => PerformanceCache::get_cache_statistics()['hit_ratio'] ?? 0,
+					'current' => $cache_stats['hit_ratio'] ?? 0,
 					'previous' => 'N/A',
 					'change' => 'N/A',
 				],


### PR DESCRIPTION
## Summary
- call `PerformanceCache::get_cache_stats()` when building the daily digest email so the hit ratio reflects benchmark data
- store the stats locally and use the cached hit ratio when populating the "Cache Performance" metric

## Testing
- php -l src/Helpers/EmailNotifications.php


------
https://chatgpt.com/codex/tasks/task_e_68cbb5fcdda0832fbc896e95a3c8f088