### PR TITLE
Refine uninstall cleanup to match current data structures

### DIFF
--- a/src/Database/CustomReportsTable.php
+++ b/src/Database/CustomReportsTable.php
@@ -46,11 +46,11 @@ class CustomReportsTable {
 	 *
 	 * @return bool
 	 */
-	public static function create_table(): bool {
-		global $wpdb;
+        public static function create_table(): bool {
+                global $wpdb;
 
-		$table_name = self::get_table_name();
-		
+                $table_name = self::get_table_name();
+
 		$charset_collate = $wpdb->get_charset_collate();
 
 		$sql = "CREATE TABLE {$table_name} (
@@ -76,8 +76,22 @@ class CustomReportsTable {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
 
-		return true;
-	}
+                return true;
+        }
+
+        /**
+         * Drop the custom reports table (uninstall helper).
+         *
+         * @return bool True on success, false on failure
+         */
+        public static function drop_table(): bool {
+                global $wpdb;
+
+                $table_name = self::get_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
+        }
 
 	/**
 	 * Insert a new custom report configuration

--- a/src/Database/CustomerJourneyTable.php
+++ b/src/Database/CustomerJourneyTable.php
@@ -138,11 +138,11 @@ class CustomerJourneyTable {
 	 *
 	 * @return bool True on success, false on failure
 	 */
-	public static function create_sessions_table(): bool {
-		global $wpdb;
+        public static function create_sessions_table(): bool {
+                global $wpdb;
 
-		$table_name = self::get_sessions_table_name();
-		$charset_collate = $wpdb->get_charset_collate();
+                $table_name = self::get_sessions_table_name();
+                $charset_collate = $wpdb->get_charset_collate();
 
 		$sql = "CREATE TABLE $table_name (
 			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -183,8 +183,36 @@ class CustomerJourneyTable {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		$result = dbDelta( $sql );
 
-		return self::sessions_table_exists();
-	}
+                return self::sessions_table_exists();
+        }
+
+        /**
+         * Drop the customer journeys events table.
+         *
+         * @return bool True on success, false on failure
+         */
+        public static function drop_table(): bool {
+                global $wpdb;
+
+                $table_name = self::get_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
+        }
+
+        /**
+         * Drop the customer journey sessions table.
+         *
+         * @return bool True on success, false on failure
+         */
+        public static function drop_sessions_table(): bool {
+                global $wpdb;
+
+                $table_name = self::get_sessions_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
+        }
 
 	/**
 	 * Insert a journey event

--- a/src/Database/FunnelTable.php
+++ b/src/Database/FunnelTable.php
@@ -119,11 +119,11 @@ class FunnelTable {
 	 *
 	 * @return bool True on success, false on failure
 	 */
-	public static function create_stages_table(): bool {
-		global $wpdb;
+        public static function create_stages_table(): bool {
+                global $wpdb;
 
-		$table_name = self::get_stages_table_name();
-		$charset_collate = $wpdb->get_charset_collate();
+                $table_name = self::get_stages_table_name();
+                $charset_collate = $wpdb->get_charset_collate();
 
 		$sql = "CREATE TABLE $table_name (
 			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
@@ -146,8 +146,36 @@ class FunnelTable {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		$result = dbDelta( $sql );
 
-		return self::stages_table_exists();
-	}
+                return self::stages_table_exists();
+        }
+
+        /**
+         * Drop the funnels table.
+         *
+         * @return bool True on success, false on failure
+         */
+        public static function drop_table(): bool {
+                global $wpdb;
+
+                $table_name = self::get_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
+        }
+
+        /**
+         * Drop the funnel stages table.
+         *
+         * @return bool True on success, false on failure
+         */
+        public static function drop_stages_table(): bool {
+                global $wpdb;
+
+                $table_name = self::get_stages_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
+        }
 
 	/**
 	 * Insert a new funnel
@@ -403,11 +431,11 @@ class FunnelTable {
 	 *
 	 * @return array
 	 */
-	public static function get_all_funnels(): array {
-		global $wpdb;
+        public static function get_all_funnels(): array {
+                global $wpdb;
 
-		$table_name = self::get_table_name();
-		$results = $wpdb->get_results( "SELECT * FROM `{$table_name}` ORDER BY created_at DESC", ARRAY_A );
+                $table_name = self::get_table_name();
+                $results = $wpdb->get_results( "SELECT * FROM `{$table_name}` ORDER BY created_at DESC", ARRAY_A );
 
 		return $results ?: [];
 	}

--- a/src/Database/SocialSentimentTable.php
+++ b/src/Database/SocialSentimentTable.php
@@ -46,11 +46,11 @@ class SocialSentimentTable {
 	 *
 	 * @return bool
 	 */
-	public static function create_table(): bool {
-		global $wpdb;
+        public static function create_table(): bool {
+                global $wpdb;
 
-		$table_name = self::get_table_name();
-		
+                $table_name = self::get_table_name();
+
 		$charset_collate = $wpdb->get_charset_collate();
 
 		$sql = "CREATE TABLE {$table_name} (
@@ -86,8 +86,22 @@ class SocialSentimentTable {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
 
-		return true;
-	}
+                return true;
+        }
+
+        /**
+         * Drop the social sentiment table (for uninstall).
+         *
+         * @return bool True on success, false on failure
+         */
+        public static function drop_table(): bool {
+                global $wpdb;
+
+                $table_name = self::get_table_name();
+                $result = $wpdb->query( "DROP TABLE IF EXISTS {$table_name}" );
+
+                return $result !== false;
+        }
 
 	/**
 	 * Insert a new sentiment analysis record

--- a/uninstall.php
+++ b/uninstall.php
@@ -25,37 +25,95 @@ if ( ! current_user_can( 'activate_plugins' ) ) {
 function fp_dms_cleanup_database_tables() {
     global $wpdb;
 
-    $table_classes = array(
-        '\\FP\\DigitalMarketing\\Database\\MetricsCacheTable' => __DIR__ . '/src/Database/MetricsCacheTable.php',
-        '\\FP\\DigitalMarketing\\Database\\AlertRulesTable' => __DIR__ . '/src/Database/AlertRulesTable.php',
-        '\\FP\\DigitalMarketing\\Database\\AnomalyRulesTable' => __DIR__ . '/src/Database/AnomalyRulesTable.php',
-        '\\FP\\DigitalMarketing\\Database\\DetectedAnomaliesTable' => __DIR__ . '/src/Database/DetectedAnomaliesTable.php',
+    $tables = array(
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\ConversionEventsTable',
+            'file'    => __DIR__ . '/src/Database/ConversionEventsTable.php',
+            'methods' => array( 'drop_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\AudienceSegmentTable',
+            'file'    => __DIR__ . '/src/Database/AudienceSegmentTable.php',
+            'methods' => array( 'drop_segments_table', 'drop_membership_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\UTMCampaignsTable',
+            'file'    => __DIR__ . '/src/Database/UTMCampaignsTable.php',
+            'methods' => array( 'drop_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\FunnelTable',
+            'file'    => __DIR__ . '/src/Database/FunnelTable.php',
+            'methods' => array( 'drop_table', 'drop_stages_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\CustomerJourneyTable',
+            'file'    => __DIR__ . '/src/Database/CustomerJourneyTable.php',
+            'methods' => array( 'drop_table', 'drop_sessions_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\CustomReportsTable',
+            'file'    => __DIR__ . '/src/Database/CustomReportsTable.php',
+            'methods' => array( 'drop_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\SocialSentimentTable',
+            'file'    => __DIR__ . '/src/Database/SocialSentimentTable.php',
+            'methods' => array( 'drop_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\MetricsCacheTable',
+            'file'    => __DIR__ . '/src/Database/MetricsCacheTable.php',
+            'methods' => array( 'drop_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\AlertRulesTable',
+            'file'    => __DIR__ . '/src/Database/AlertRulesTable.php',
+            'methods' => array( 'drop_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\AnomalyRulesTable',
+            'file'    => __DIR__ . '/src/Database/AnomalyRulesTable.php',
+            'methods' => array( 'drop_table' ),
+        ),
+        array(
+            'class'   => '\\FP\\DigitalMarketing\\Database\\DetectedAnomaliesTable',
+            'file'    => __DIR__ . '/src/Database/DetectedAnomaliesTable.php',
+            'methods' => array( 'drop_table' ),
+        ),
     );
 
-    foreach ( $table_classes as $class => $path ) {
-        if ( ! class_exists( $class ) && file_exists( $path ) ) {
-            require_once $path;
+    foreach ( $tables as $definition ) {
+        $class = $definition['class'];
+
+        if ( ! class_exists( $class ) && isset( $definition['file'] ) && file_exists( $definition['file'] ) ) {
+            require_once $definition['file'];
         }
 
-        if ( class_exists( $class ) && method_exists( $class, 'drop_table' ) ) {
-            $class::drop_table();
+        if ( ! class_exists( $class ) ) {
+            continue;
+        }
+
+        foreach ( $definition['methods'] as $method ) {
+            if ( method_exists( $class, $method ) ) {
+                call_user_func( array( $class, $method ) );
+            }
         }
     }
 
-    // List of custom tables to remove
-    $tables = array(
-        $wpdb->prefix . 'fp_dms_clients',
-        $wpdb->prefix . 'fp_dms_analytics_data',
-        $wpdb->prefix . 'fp_dms_campaigns',
-        $wpdb->prefix . 'fp_dms_conversion_events',
-        $wpdb->prefix . 'fp_dms_audience_segments',
-        $wpdb->prefix . 'fp_dms_alerts',
-        $wpdb->prefix . 'fp_dms_performance_metrics'
-    );
+    // Drop any legacy tables that may still exist from older versions.
+    if ( isset( $wpdb ) && method_exists( $wpdb, 'query' ) ) {
+        $legacy_tables = array(
+            $wpdb->prefix . 'fp_dms_clients',
+            $wpdb->prefix . 'fp_dms_analytics_data',
+            $wpdb->prefix . 'fp_dms_campaigns',
+            $wpdb->prefix . 'fp_dms_alerts',
+            $wpdb->prefix . 'fp_dms_performance_metrics',
+        );
 
-    // Drop each table
-    foreach ( $tables as $table ) {
-        $wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+        foreach ( $legacy_tables as $table ) {
+            $wpdb->query( "DROP TABLE IF EXISTS {$table}" );
+        }
     }
 }
 
@@ -63,37 +121,107 @@ function fp_dms_cleanup_database_tables() {
  * Cleanup WordPress options
  */
 function fp_dms_cleanup_options() {
-    // Plugin settings
-    delete_option( 'fp_dms_settings' );
-    delete_option( 'fp_dms_ga4_settings' );
-    delete_option( 'fp_dms_google_ads_settings' );
-    delete_option( 'fp_dms_gsc_settings' );
-    delete_option( 'fp_dms_clarity_settings' );
-    delete_option( 'fp_dms_seo_settings' );
-    delete_option( 'fp_dms_performance_settings' );
-    delete_option( 'fp_dms_alert_settings' );
-    delete_option( 'fp_dms_email_settings' );
-    
-    // Plugin status and version
-    delete_option( 'fp_dms_version' );
-    delete_option( 'fp_dms_activation_time' );
-    delete_option( 'fp_dms_setup_completed' );
-    
-    // Cache and temporary data
-    delete_option( 'fp_dms_cache_settings' );
-    delete_option( 'fp_dms_performance_cache' );
-    delete_option( 'fp_dms_analytics_cache' );
-    
-    // API keys and tokens (security cleanup)
-    delete_option( 'fp_dms_ga4_credentials' );
-    delete_option( 'fp_dms_google_ads_credentials' );
-    delete_option( 'fp_dms_gsc_credentials' );
-    
-    // Cleanup any transients
-    delete_transient( 'fp_dms_ga4_data' );
-    delete_transient( 'fp_dms_google_ads_data' );
-    delete_transient( 'fp_dms_gsc_data' );
-    delete_transient( 'fp_dms_clarity_data' );
+    global $wpdb;
+
+    $option_names = array(
+        // Core settings stored through the Settings API.
+        'fp_digital_marketing_settings',
+        'fp_digital_marketing_api_keys',
+        'fp_digital_marketing_sync_settings',
+        'fp_digital_marketing_cache_settings',
+        'fp_digital_marketing_seo_settings',
+        'fp_digital_marketing_sitemap_settings',
+        'fp_digital_marketing_schema_settings',
+        'fp_digital_marketing_email_settings',
+        'fp_digital_marketing_demo_option',
+        'fp_digital_marketing_report_config',
+        'fp_digital_marketing_user_feedback',
+        'fp_digital_marketing_wizard_progress',
+        'fp_digital_marketing_wizard_completed',
+
+        // Performance cache metrics.
+        'fp_digital_marketing_benchmark_data',
+        'fp_digital_marketing_benchmark_results',
+        'fp_digital_marketing_cache_stats',
+
+        // Setup wizard and onboarding flags.
+        'fp_dms_setup_completed',
+        'fp_dms_setup_completed_time',
+        'fp_dms_analytics_settings',
+        'fp_dms_seo_settings',
+        'fp_dms_performance_settings',
+
+        // Logs and monitoring data.
+        'fp_dms_security_logs',
+        'fp_dms_alert_logs',
+        'fp_dms_anomaly_logs',
+        'fp_dms_report_logs',
+        'fp_dms_sync_logs',
+        'fp_dms_performance_metrics',
+        'fp_dms_enable_performance_monitoring',
+
+        // OAuth tokens and integration state.
+        'fp_dms_google_oauth_tokens',
+        'fp_dms_google_oauth_settings',
+        'fp_dms_oauth_state',
+
+        // Capability registration cache.
+        'fp_dms_capabilities_registered',
+
+        // Migration/compatibility settings that may be present.
+        'fp_dms_analytics_ga4_measurement_id',
+        'fp_dms_analytics_ua_tracking_id',
+        'fp_dms_analytics_track_users',
+        'fp_dms_gsc_property_url',
+        'fp_dms_adsense_client_id',
+        'fp_dms_crux_api_key',
+    );
+
+    foreach ( $option_names as $option ) {
+        delete_option( $option );
+    }
+
+    // Remove transient-based state used across subsystems.
+    $transient_names = array(
+        'fp_dms_activation_redirect',
+        'fp_dms_security_audit',
+    );
+
+    foreach ( $transient_names as $transient ) {
+        delete_transient( $transient );
+    }
+
+    if ( isset( $wpdb ) && property_exists( $wpdb, 'options' ) ) {
+        // Remove dynamically named transients generated by the cache, export and alert subsystems.
+        $wpdb->query(
+            "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_fp_dms_%'"
+        );
+        $wpdb->query(
+            "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_fp_dms_%'"
+        );
+        $wpdb->query(
+            "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_fp_digital_marketing_%'"
+        );
+        $wpdb->query(
+            "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_fp_digital_marketing_%'"
+        );
+    }
+
+    // Clean up legacy options from early releases if they still exist.
+    $legacy_options = array(
+        'fp_dms_version',
+        'fp_dms_activation_time',
+        'fp_dms_cache_settings',
+        'fp_dms_performance_cache',
+        'fp_dms_analytics_cache',
+        'fp_dms_ga4_credentials',
+        'fp_dms_google_ads_credentials',
+        'fp_dms_gsc_credentials',
+    );
+
+    foreach ( $legacy_options as $legacy_option ) {
+        delete_option( $legacy_option );
+    }
 }
 
 /**
@@ -156,12 +284,65 @@ function fp_dms_cleanup_posts() {
  * Cleanup scheduled events
  */
 function fp_dms_cleanup_scheduled_events() {
-    // Remove scheduled cron events
-    wp_clear_scheduled_hook( 'fp_dms_sync_analytics_data' );
-    wp_clear_scheduled_hook( 'fp_dms_check_performance_metrics' );
-    wp_clear_scheduled_hook( 'fp_dms_send_alert_emails' );
-    wp_clear_scheduled_hook( 'fp_dms_cleanup_old_data' );
-    wp_clear_scheduled_hook( 'fp_dms_refresh_cache' );
+    $hooks = array(
+        // Current scheduled events.
+        'fp_dms_sync_data_sources',
+        'fp_dms_generate_reports',
+        'fp_dms_daily_digest',
+        'fp_dms_cache_warmup',
+        'fp_dms_evaluate_all_segments',
+        'fp_dms_cleanup_exports',
+        'fp_dms_cleanup_export_file',
+
+        // Legacy hooks kept for backwards compatibility.
+        'fp_dms_sync_analytics_data',
+        'fp_dms_check_performance_metrics',
+        'fp_dms_send_alert_emails',
+        'fp_dms_cleanup_old_data',
+        'fp_dms_refresh_cache',
+    );
+
+    foreach ( $hooks as $hook ) {
+        wp_clear_scheduled_hook( $hook );
+    }
+}
+
+/**
+ * Recursively delete a directory and its contents.
+ *
+ * @param string $directory Absolute path to the directory.
+ * @return void
+ */
+function fp_dms_delete_directory( $directory ) {
+    if ( ! is_dir( $directory ) ) {
+        return;
+    }
+
+    $items = scandir( $directory );
+    if ( false === $items ) {
+        return;
+    }
+
+    foreach ( $items as $item ) {
+        if ( '.' === $item || '..' === $item ) {
+            continue;
+        }
+
+        $path = $directory . '/' . $item;
+
+        if ( is_dir( $path ) ) {
+            fp_dms_delete_directory( $path );
+            continue;
+        }
+
+        if ( function_exists( 'wp_delete_file' ) ) {
+            wp_delete_file( $path );
+        } else {
+            @unlink( $path );
+        }
+    }
+
+    @rmdir( $directory );
 }
 
 /**
@@ -169,18 +350,20 @@ function fp_dms_cleanup_scheduled_events() {
  */
 function fp_dms_cleanup_files() {
     $upload_dir = wp_upload_dir();
-    $plugin_upload_dir = $upload_dir['basedir'] . '/fp-dms/';
-    
-    if ( is_dir( $plugin_upload_dir ) ) {
-        // Remove all files in the plugin upload directory
-        $files = glob( $plugin_upload_dir . '*' );
-        foreach ( $files as $file ) {
-            if ( is_file( $file ) ) {
-                unlink( $file );
-            }
+    if ( empty( $upload_dir['basedir'] ) ) {
+        return;
+    }
+
+    $directories = array(
+        $upload_dir['basedir'] . '/fp-dms-exports',
+        $upload_dir['basedir'] . '/fp-dms-reports',
+        $upload_dir['basedir'] . '/fp-dms', // Legacy directory from early releases.
+    );
+
+    foreach ( $directories as $directory ) {
+        if ( is_dir( $directory ) ) {
+            fp_dms_delete_directory( $directory );
         }
-        // Remove the directory
-        rmdir( $plugin_upload_dir );
     }
 }
 


### PR DESCRIPTION
## Summary
- drop plugin tables via the database handler classes and add missing drop helpers for funnels, journeys, custom reports, and social sentiment data
- align option, transient, cron, and file cleanup with the settings, monitoring, and export features currently used by the suite
- preserve removal of legacy database objects and options for backwards compatibility while clearing dynamically generated cache/export transients

## Testing
- `composer test` *(fails: phpunit not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbfd0d3280832f94e98f4083546496