### PR TITLE
Improve conversion event cache invalidation

### DIFF
--- a/src/Helpers/ConversionEventManager.php
+++ b/src/Helpers/ConversionEventManager.php
@@ -405,18 +405,18 @@ class ConversionEventManager {
 	 * @param string $event_type Event type
 	 * @return void
 	 */
-	private static function clear_related_caches( int $client_id, string $event_type ): void {
-		// Clear conversion-related performance caches
-		$cache_patterns = [
-			"metrics_aggregated_client_{$client_id}_*",
-			"conversion_events_client_{$client_id}_*",
-			"conversion_summary_{$client_id}_*",
-		];
+        private static function clear_related_caches( int $client_id, string $event_type ): void {
+                $base_key = PerformanceCache::generate_metrics_key([
+                        'client_id' => $client_id,
+                ]);
 
-		foreach ( $cache_patterns as $pattern ) {
-			PerformanceCache::clear_cache_by_pattern( $pattern );
-		}
-	}
+                $prefix_end = strrpos( $base_key, '_' );
+                $prefix = false === $prefix_end ? $base_key : substr( $base_key, 0, $prefix_end );
+                $pattern = $prefix . '_*';
+
+                PerformanceCache::clear_cache_by_pattern( $pattern, PerformanceCache::CACHE_GROUP_AGGREGATED );
+                PerformanceCache::clear_cache_by_pattern( $pattern, PerformanceCache::CACHE_GROUP_REPORTS );
+        }
 
 	/**
 	 * Get conversion funnel analysis

--- a/src/Helpers/PerformanceCache.php
+++ b/src/Helpers/PerformanceCache.php
@@ -448,10 +448,61 @@ class PerformanceCache {
 	 * @param array $params Query parameters
 	 * @return string Cache key
 	 */
-	public static function generate_metrics_key( array $params ): string {
-		ksort( $params );
-		return 'metrics_' . md5( serialize( $params ) );
-	}
+        public static function generate_metrics_key( array $params ): string {
+                ksort( $params );
+
+                $prefix_parts = [];
+
+                $client_component = self::normalize_key_component( $params['client_id'] ?? 'global' );
+                if ( '' === $client_component ) {
+                        $client_component = 'global';
+                }
+                $prefix_parts[] = 'client_' . $client_component;
+
+                if ( array_key_exists( 'method', $params ) ) {
+                        $method_component = self::normalize_key_component( $params['method'] );
+                        if ( '' === $method_component ) {
+                                $method_component = 'default';
+                        }
+                        $prefix_parts[] = 'method_' . $method_component;
+                }
+
+                if ( array_key_exists( 'segment', $params ) ) {
+                        $segment_component = self::normalize_key_component( $params['segment'] );
+                        if ( '' === $segment_component ) {
+                                $segment_component = 'all';
+                        }
+                        $prefix_parts[] = 'segment_' . $segment_component;
+                }
+
+                $prefix = implode( '_', $prefix_parts );
+
+                return sprintf(
+                        'metrics_%s_%s',
+                        $prefix,
+                        md5( serialize( $params ) )
+                );
+        }
+
+        /**
+         * Normalize a value for usage in cache key components.
+         *
+         * @param mixed $value Value to normalize
+         * @return string Normalized value limited to alphanumeric characters
+         */
+        private static function normalize_key_component( $value ): string {
+                if ( is_bool( $value ) ) {
+                        $value = $value ? 'true' : 'false';
+                } elseif ( is_array( $value ) || is_object( $value ) ) {
+                        $encoded = json_encode( $value );
+                        $value = false !== $encoded ? $encoded : '';
+                }
+
+                $value = strtolower( (string) $value );
+                $value = preg_replace( '/[^a-z0-9]+/', '_', $value );
+
+                return trim( (string) $value, '_' );
+        }
 
 	/**
 	 * Generate cache key for reports


### PR DESCRIPTION
## Summary
- update metrics cache key generation to include readable client/method/segment prefixes and normalize components
- clear conversion-related caches using the new key prefix in both aggregated and report cache groups

## Testing
- php -l src/Helpers/PerformanceCache.php
- php -l src/Helpers/ConversionEventManager.php

------
https://chatgpt.com/codex/tasks/task_e_68cc2457d158832fbf535e986528edfe