### PR TITLE
Make build script read version from plugin header

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,15 +56,12 @@ jobs:
       run: composer install --no-dev --optimize-autoloader --no-interaction
     
     - name: Run build script
+      env:
+        PLUGIN_VERSION: ${{ steps.version.outputs.version }}
       run: |
         # Make build script executable
         chmod +x build.sh
-        
-        # Update version in build script if version override is provided
-        if [ -n "${{ github.event.inputs.version_override }}" ]; then
-          sed -i 's/VERSION=".*"/VERSION="${{ steps.version.outputs.version }}"/' build.sh
-        fi
-        
+
         # Run the build process
         ./build.sh
     

--- a/build.sh
+++ b/build.sh
@@ -5,9 +5,12 @@
 
 set -e
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${ROOT}"
+
 # Configuration
 PLUGIN_NAME="fp-digital-marketing-suite"
-VERSION="1.0.0"
+VERSION="${PLUGIN_VERSION:-$(grep "Version:" "${ROOT}/fp-digital-marketing-suite.php" | head -1 | awk -F': ' '{print $2}' | tr -d '\r')}"
 BUILD_DIR="build"
 DIST_DIR="dist"
 

--- a/fp-digital-marketing-suite.php
+++ b/fp-digital-marketing-suite.php
@@ -3,7 +3,7 @@
  * Plugin Name: FP Digital Marketing Suite
  * Plugin URI: https://github.com/franpass87/FP-Digital-Marketing-Suite
  * Description: A comprehensive digital marketing toolkit with advanced client metadata management.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Francesco Passarelli
  * License: MIT
  * Text Domain: fp-digital-marketing
@@ -19,7 +19,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // Define plugin constants.
-define( 'FP_DIGITAL_MARKETING_VERSION', '1.0.0' );
+define( 'FP_DIGITAL_MARKETING_VERSION', '1.0.1' );
 define( 'FP_DIGITAL_MARKETING_PLUGIN_FILE', __FILE__ );
 define( 'FP_DIGITAL_MARKETING_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'FP_DIGITAL_MARKETING_PLUGIN_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
## Summary
- derive the build version dynamically in build.sh by inspecting the plugin header and honoring an optional PLUGIN_VERSION override
- update the GitHub Actions workflow to pass the computed version through the environment instead of rewriting the script
- bump the plugin version metadata to 1.0.1 for the new release artifact

## Testing
- ./build.sh
- bash -lc 'set -e; VERSION="1.0.1"; PLUGIN_NAME="fp-digital-marketing-suite"; ZIP_FILE="dist/${PLUGIN_NAME}-${VERSION}.zip"; CHECKSUM_FILE="dist/${PLUGIN_NAME}-${VERSION}.zip.sha256"; if [ ! -f "${ZIP_FILE}" ]; then echo "❌ ZIP file not found: ${ZIP_FILE}"; exit 1; fi; if [ ! -f "${CHECKSUM_FILE}" ]; then echo "❌ Checksum file not found: ${CHECKSUM_FILE}"; exit 1; fi; unzip -t "${ZIP_FILE}" > /dev/null 2>&1; echo "✅ Build verification successful"; echo "📦 Package: ${ZIP_FILE}"; echo "📏 Size: $(du -h ${ZIP_FILE} | cut -f1)"; echo "🔐 Checksum: $(cat ${CHECKSUM_FILE})"; echo "🔍 Verifying plugin structure..."; unzip -l "${ZIP_FILE}" | head -20; if ! unzip -l "${ZIP_FILE}" | grep -q "${PLUGIN_NAME}/${PLUGIN_NAME}.php"; then echo "❌ Main plugin file not found in ZIP"; exit 1; fi; echo "✅ Plugin structure verification passed"'


------
https://chatgpt.com/codex/tasks/task_e_68cc4ae1dfc4832fbe1ee7d580671911