### PR TITLE
Ensure admin menus defer to MenuManager state

### DIFF
--- a/src/Admin/Reports.php
+++ b/src/Admin/Reports.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace FP\DigitalMarketing\Admin;
 
 use Exception;
+use FP\DigitalMarketing\Admin\MenuManager;
 use FP\DigitalMarketing\Helpers\DataSources;
 use FP\DigitalMarketing\Helpers\ReportGenerator;
 use FP\DigitalMarketing\Helpers\ReportScheduler;
@@ -62,8 +63,8 @@ class Reports {
 	 * @return void
 	 */
 	public function add_admin_menu(): void {
-		// Check if centralized MenuManager is active
-		if ( class_exists( '\FP\DigitalMarketing\Admin\MenuManager' ) ) {
+                // Check if centralized MenuManager is active
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
 			// MenuManager will handle menu registration
 			return;
 		}

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace FP\DigitalMarketing\Admin;
 
+use FP\DigitalMarketing\Admin\MenuManager;
 use FP\DigitalMarketing\DataSources\GoogleOAuth;
 use FP\DigitalMarketing\DataSources\GoogleAnalytics4;
 use FP\DigitalMarketing\DataSources\GoogleSearchConsole;
@@ -160,8 +161,8 @@ class Settings {
 	 * @return void
 	 */
 	public function add_admin_menu(): void {
-		// Check if centralized MenuManager is active
-		if ( class_exists( '\FP\DigitalMarketing\Admin\MenuManager' ) ) {
+                // Check if centralized MenuManager is active
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
 			// MenuManager will handle menu registration
 			return;
 		}

--- a/tests/AdminMenuFallbackTest.php
+++ b/tests/AdminMenuFallbackTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Tests for admin menu fallback behavior when MenuManager state changes.
+ *
+ * @package FP_Digital_Marketing_Suite
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use FP\DigitalMarketing\Admin\MenuManager;
+use FP\DigitalMarketing\Admin\Settings;
+use FP\DigitalMarketing\Admin\Reports;
+
+if ( ! function_exists( 'add_submenu_page' ) ) {
+        /**
+         * Minimal stub for WordPress add_submenu_page() used during testing.
+         *
+         * @return string
+         */
+        function add_submenu_page(
+                string $parent_slug,
+                string $page_title,
+                string $menu_title,
+                string $capability,
+                string $menu_slug,
+                $callback = ''
+        ) {
+                global $fp_dms_submenu_calls;
+
+                if ( ! is_array( $fp_dms_submenu_calls ) ) {
+                        $fp_dms_submenu_calls = [];
+                }
+
+                $fp_dms_submenu_calls[] = [
+                        'parent_slug' => $parent_slug,
+                        'page_title'  => $page_title,
+                        'menu_title'  => $menu_title,
+                        'capability'  => $capability,
+                        'menu_slug'   => $menu_slug,
+                        'callback'    => $callback,
+                ];
+
+                return $menu_slug;
+        }
+}
+
+/**
+ * Ensure Settings/Reports submenus fall back correctly when MenuManager is inactive.
+ */
+class AdminMenuFallbackTest extends TestCase {
+
+        /**
+         * Reset submenu capture array before each test.
+         */
+        protected function setUp(): void {
+                parent::setUp();
+
+                global $fp_dms_submenu_calls;
+                $fp_dms_submenu_calls = [];
+
+                $this->set_menu_manager_initialized( false );
+        }
+
+        /**
+         * Ensure we reset the MenuManager initialization flag after each test.
+         */
+        protected function tearDown(): void {
+                $this->set_menu_manager_initialized( false );
+
+                parent::tearDown();
+        }
+
+        /**
+         * Helper to flip the private MenuManager initialization flag.
+         */
+        private function set_menu_manager_initialized( bool $state ): void {
+                $reflection = new \ReflectionClass( MenuManager::class );
+                $property   = $reflection->getProperty( 'initialized' );
+                $property->setAccessible( true );
+                $property->setValue( null, $state );
+        }
+
+        /**
+         * When MenuManager is inactive the legacy submenus should still register.
+         */
+        public function test_submenus_register_when_menu_manager_inactive(): void {
+                $settings = new Settings();
+                $reports  = new Reports();
+
+                $settings->add_admin_menu();
+                $reports->add_admin_menu();
+
+                global $fp_dms_submenu_calls;
+                $menu_slugs = array_column( $fp_dms_submenu_calls, 'menu_slug' );
+
+                $this->assertContains( 'fp-digital-marketing-settings', $menu_slugs );
+                $this->assertContains( 'fp-digital-marketing-reports', $menu_slugs );
+        }
+
+        /**
+         * When MenuManager is initialized it should prevent duplicate submenu registration.
+         */
+        public function test_submenus_not_registered_when_menu_manager_initialized(): void {
+                $menu_manager = new MenuManager();
+                $menu_manager->init();
+
+                $settings = new Settings();
+                $reports  = new Reports();
+
+                $settings->add_admin_menu();
+                $reports->add_admin_menu();
+
+                global $fp_dms_submenu_calls;
+                $this->assertSame( [], $fp_dms_submenu_calls );
+        }
+}


### PR DESCRIPTION
## Summary
- update the Settings and Reports admin pages to import MenuManager and only skip legacy submenu registration when the manager is initialized
- add automated coverage that captures submenu registrations so we can verify the fallback is active when MenuManager is disabled and suppressed when it is initialized

## Testing
- vendor/bin/phpunit *(fails: numerous pre-existing failures in the suite, menu fallback assertions pass)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6f76985c832f90b1beb30f39fdb8