### PR TITLE
Adjust funnel analysis legacy menu parent

### DIFF
--- a/src/Admin/FunnelAnalysisAdmin.php
+++ b/src/Admin/FunnelAnalysisAdmin.php
@@ -57,8 +57,8 @@ class FunnelAnalysisAdmin {
 		}
 
 		// Legacy menu registration (fallback)
-		add_submenu_page(
-			'fp-digital-marketing',
+               add_submenu_page(
+                       'fp-digital-marketing-dashboard',
 			__( 'Funnel Analysis', 'fp-digital-marketing' ),
 			__( 'Funnel Analysis', 'fp-digital-marketing' ),
 			Capabilities::FUNNEL_ANALYSIS,


### PR DESCRIPTION
## Summary
- update the legacy submenu parent slug to `fp-digital-marketing-dashboard` so the fallback menu entry matches the dashboard registration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0f59162c4832f88f851ed5260d195