### PR TITLE
Restore UTM submenu fallback when MenuManager is inactive

### DIFF
--- a/src/Admin/UTMCampaignManager.php
+++ b/src/Admin/UTMCampaignManager.php
@@ -9,9 +9,10 @@ declare(strict_types=1);
 
 namespace FP\DigitalMarketing\Admin;
 
-use FP\DigitalMarketing\Models\UTMCampaign;
-use FP\DigitalMarketing\Helpers\UTMGenerator;
+use FP\DigitalMarketing\Admin\MenuManager;
 use FP\DigitalMarketing\Helpers\Capabilities;
+use FP\DigitalMarketing\Helpers\UTMGenerator;
+use FP\DigitalMarketing\Models\UTMCampaign;
 
 /**
  * UTM Campaign Manager class for admin interface
@@ -55,12 +56,12 @@ class UTMCampaignManager {
 	 *
 	 * @return void
 	 */
-	public function add_admin_menu(): void {
-		// Check if centralized MenuManager is active
-		if ( class_exists( '\FP\DigitalMarketing\Admin\MenuManager' ) ) {
-			// MenuManager will handle menu registration
-			return;
-		}
+        public function add_admin_menu(): void {
+                // Check if centralized MenuManager is active
+                if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
+                        // MenuManager will handle menu registration
+                        return;
+                }
 
 		// Legacy menu registration (fallback)
 		add_submenu_page(


### PR DESCRIPTION
## Summary
- import the centralized MenuManager in the UTM campaign admin handler
- update the admin menu guard to only defer to MenuManager when it is initialized so the legacy submenu still loads otherwise

## Testing
- not run (WordPress environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0fb15cd70832f87ea74182dbcfc04