### PR TITLE
Fix dashboard asset URLs

### DIFF
--- a/src/Admin/Dashboard.php
+++ b/src/Admin/Dashboard.php
@@ -153,24 +153,16 @@ class Dashboard {
 			true
 		);
 
-		// Enqueue dashboard script
-		wp_enqueue_script(
-			'fp-dms-dashboard',
-			plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'assets/js/dashboard.js',
-			[ 'jquery', 'chartjs' ],
-			'1.0.0',
-			true
-		);
+                // Enqueue dashboard script
+                wp_enqueue_script(
+                        'fp-dms-dashboard',
+                        FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/dashboard.js',
+                        [ 'jquery', 'chartjs' ],
+                        '1.0.0',
+                        true
+                );
 
-		// Enqueue dashboard styles
-		wp_enqueue_style(
-			'fp-dms-dashboard',
-			plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'assets/css/dashboard.css',
-			[],
-			'1.0.0'
-		);
-
-		// Localize script for AJAX
+                // Localize script for AJAX
 		wp_localize_script( 'fp-dms-dashboard', 'fpDmsDashboard', [
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
 			'nonce' => wp_create_nonce( 'fp_dms_dashboard' ),


### PR DESCRIPTION
## Summary
- use the FP_DIGITAL_MARKETING_PLUGIN_URL constant when registering dashboard JavaScript and CSS assets
- remove the redundant dashboard stylesheet enqueue that used an outdated path

## Testing
- php -l src/Admin/Dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68d10dd3c100832fbb0b30c1452525b1