### PR TITLE
Fix reports settings link to plugin page

### DIFF
--- a/src/Admin/Reports.php
+++ b/src/Admin/Reports.php
@@ -1506,7 +1506,7 @@ $is_available = \FP\DigitalMarketing\Helpers\DataSources::is_data_source_availab
 				<div class="notice notice-warning inline">
 					<p>
 						<?php esc_html_e( 'Per visualizzare le metriche GA4, configura prima la connessione nelle', 'fp-digital-marketing' ); ?>
-						<a href="<?php echo esc_url( admin_url( 'options-general.php?page=fp-digital-marketing-settings' ) ); ?>">
+                                                <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-digital-marketing-settings' ) ); ?>">
 							<?php esc_html_e( 'Impostazioni', 'fp-digital-marketing' ); ?>
 						</a>.
 					</p>
@@ -1556,7 +1556,7 @@ $is_available = \FP\DigitalMarketing\Helpers\DataSources::is_data_source_availab
 				<div class="notice notice-warning inline">
 					<p>
 						<?php esc_html_e( 'Per visualizzare le metriche Search Console, configura prima la connessione nelle', 'fp-digital-marketing' ); ?>
-						<a href="<?php echo esc_url( admin_url( 'options-general.php?page=fp-digital-marketing-settings' ) ); ?>">
+                                                <a href="<?php echo esc_url( admin_url( 'admin.php?page=fp-digital-marketing-settings' ) ); ?>">
 							<?php esc_html_e( 'Impostazioni', 'fp-digital-marketing' ); ?>
 						</a>.
 					</p>


### PR DESCRIPTION
## Summary
- update the GA4 and GSC settings helper links on the Reports page to target the plugin settings panel directly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d117850058832fa0bca1ad21e965c3