### PR TITLE
Decrypt Google OAuth secret before OAuth calls

### DIFF
--- a/src/DataSources/GoogleOAuth.php
+++ b/src/DataSources/GoogleOAuth.php
@@ -78,15 +78,25 @@ class GoogleOAuth {
 	 *
 	 * @return array OAuth credentials
 	 */
-	private function get_oauth_credentials(): array {
-		$api_keys = get_option( 'fp_digital_marketing_api_keys', [] );
-		
-		return [
-			'client_id' => $api_keys['google_client_id'] ?? '',
-			'client_secret' => $api_keys['google_client_secret'] ?? '',
-			'redirect_uri' => admin_url( 'admin.php?page=fp-digital-marketing-settings&ga4_callback=1' ),
-		];
-	}
+        private function get_oauth_credentials(): array {
+                $api_keys = get_option( 'fp_digital_marketing_api_keys', [] );
+
+                $client_id = $api_keys['google_client_id'] ?? '';
+                $raw_client_secret = $api_keys['google_client_secret'] ?? '';
+                $client_secret = '';
+
+                if ( ! empty( $raw_client_secret ) ) {
+                        $decrypted_secret = Security::decrypt_sensitive_data( $raw_client_secret );
+
+                        $client_secret = ! empty( $decrypted_secret ) ? $decrypted_secret : $raw_client_secret;
+                }
+
+                return [
+                        'client_id' => $client_id,
+                        'client_secret' => $client_secret,
+                        'redirect_uri' => admin_url( 'admin.php?page=fp-digital-marketing-settings&ga4_callback=1' ),
+                ];
+        }
 
 	/**
 	 * Check if OAuth is properly configured

--- a/src/DataSources/GoogleOAuth.php
+++ b/src/DataSources/GoogleOAuth.php
@@ -85,10 +85,10 @@ class GoogleOAuth {
                 $raw_client_secret = $api_keys['google_client_secret'] ?? '';
                 $client_secret = '';
 
-                if ( ! empty( $raw_client_secret ) ) {
+                if ( $raw_client_secret !== '' && $raw_client_secret !== null ) {
                         $decrypted_secret = Security::decrypt_sensitive_data( $raw_client_secret );
 
-                        $client_secret = ! empty( $decrypted_secret ) ? $decrypted_secret : $raw_client_secret;
+                        $client_secret = ($decrypted_secret !== '' && $decrypted_secret !== null) ? $decrypted_secret : $raw_client_secret;
                 }
 
                 return [


### PR DESCRIPTION
## Summary
- decrypt the stored Google OAuth client secret when loading credentials
- fall back to the raw stored secret only if decryption returns nothing so existing plaintext secrets still work

## Testing
- composer test *(fails: phpunit: not found)*
- php phpunit.phar -c phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d128371a3c832fb128b29244b04589