### PR TITLE
Prevent async loading for wp.ajax dependent admin scripts

### DIFF
--- a/src/Helpers/AdminOptimizations.php
+++ b/src/Helpers/AdminOptimizations.php
@@ -195,15 +195,35 @@ class AdminOptimizations {
             return $tag;
         }
 
+        // Scripts that interact with wp.ajax (or depend on WordPress-provided globals)
+        // must retain execution order. Use defer so dependencies run first.
+        $defer_handles = apply_filters(
+            'fp_dms_admin_defer_script_handles',
+            [
+                'fp-dms-admin-optimizations',
+            ]
+        );
+
+        if ( in_array( $handle, $defer_handles, true ) ) {
+            if ( strpos( $tag, ' defer' ) === false ) {
+                $tag = str_replace( ' src', ' defer src', $tag );
+            }
+
+            return $tag;
+        }
+
         // Add async to non-critical scripts
         $async_handles = [
-            'fp-dms-admin-optimizations',
             'fp-dms-analytics',
             'fp-dms-charts'
         ];
 
         if ( in_array( $handle, $async_handles, true ) ) {
-            return str_replace( ' src', ' async src', $tag );
+            if ( strpos( $tag, ' async' ) === false ) {
+                $tag = str_replace( ' src', ' async src', $tag );
+            }
+
+            return $tag;
         }
 
         return $tag;


### PR DESCRIPTION
## Summary
- ensure the admin optimizations script and other wp.ajax consumers load with defer instead of async
- keep remaining lightweight admin assets loading asynchronously for performance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d15ddbac14832fa797d8c1b829a559