### PR TITLE
Display cache notices above performance grid

### DIFF
--- a/src/Admin/CachePerformance.php
+++ b/src/Admin/CachePerformance.php
@@ -229,6 +229,11 @@ class CachePerformance {
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Cache Performance - Analisi e Benchmark', 'fp-digital-marketing' ); ?></h1>
 			
+			<?php
+			settings_errors( 'cache_performance' );
+			settings_errors( 'cache_settings' );
+			?>
+
 			<?php $this->render_benchmark_actions(); ?>
 			
 			<div class="cache-performance-grid">


### PR DESCRIPTION
## Summary
- show cache performance and cache settings notices immediately below the page heading so they appear before the analytics grid

## Testing
- php <<'PHP' (stubbed WordPress environment) to run handle_actions() and render_page(), confirming the benchmark notice renders above the grid


------
https://chatgpt.com/codex/tasks/task_e_68d19f4f579c832f95f5c49aeab41620