### PR TITLE
Fix Core Web Vitals cache disabled handling

### DIFF
--- a/src/DataSources/CoreWebVitals.php
+++ b/src/DataSources/CoreWebVitals.php
@@ -96,10 +96,13 @@ class CoreWebVitals {
 			'filters' => $filters,
 		]);
 
-		$cached_data = PerformanceCache::get_cached( $cache_key, PerformanceCache::CACHE_GROUP_METRICS );
-		if ( $cached_data !== false ) {
-			return $cached_data;
-		}
+               $cached_data = null;
+               if ( PerformanceCache::is_cache_enabled() ) {
+                       $cached_data = PerformanceCache::get_cached( $cache_key, PerformanceCache::CACHE_GROUP_METRICS );
+                       if ( $cached_data !== false && $cached_data !== null ) {
+                               return $cached_data;
+                       }
+               }
 
 		try {
 			if ( ! $this->is_connected() ) {


### PR DESCRIPTION
## Summary
- guard the Core Web Vitals metrics cache lookup behind the cache-enabled setting
- ensure fetch_metrics only short-circuits when real cached metrics are available

## Testing
- php -d detect_unicode=0 phpunit.phar --configuration phpunit.xml

------
https://chatgpt.com/codex/tasks/task_e_68d1a2c21b68832f9c71ac414595cc2c