### PR TITLE
Add redirect after cache performance actions

### DIFF
--- a/src/Admin/CachePerformance.php
+++ b/src/Admin/CachePerformance.php
@@ -76,26 +76,38 @@ class CachePerformance {
 			return;
 		}
 
+		$handled_action = false;
+
 		switch ( $action ) {
 			case 'run_benchmark':
 				$this->run_performance_benchmark();
+				$handled_action = true;
 				break;
 				
 			case 'run_load_test':
 				$this->run_load_test();
+				$handled_action = true;
 				break;
 				
 			case 'run_memory_test':
 				$this->run_memory_test();
+				$handled_action = true;
 				break;
 				
 			case 'clear_cache':
 				$this->clear_cache();
+				$handled_action = true;
 				break;
 				
 			case 'clear_stats':
 				$this->clear_statistics();
+				$handled_action = true;
 				break;
+		}
+
+		if ( $handled_action ) {
+			wp_safe_redirect( remove_query_arg( [ 'action', '_wpnonce' ] ) );
+			exit;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add a redirect after handling cache performance actions so the page reloads without action and nonce query args
- only trigger the redirect when a recognized cache performance action runs to avoid unnecessary navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1a65d3830832f91fd7fa5aec53ed0