### PR TITLE
Gate admin menus on MenuManager initialization

### DIFF
--- a/src/Admin/AlertingAdmin.php
+++ b/src/Admin/AlertingAdmin.php
@@ -35,7 +35,9 @@ class AlertingAdmin {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_init', [ $this, 'handle_form_submission' ] );
 		add_action( 'admin_notices', [ $this, 'display_alert_notices' ] );
 		add_action( 'wp_ajax_dismiss_alert_notice', [ $this, 'dismiss_alert_notice' ] );

--- a/src/Admin/AnomalyDetectionAdmin.php
+++ b/src/Admin/AnomalyDetectionAdmin.php
@@ -37,7 +37,9 @@ class AnomalyDetectionAdmin {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_init', [ $this, 'handle_form_submission' ] );
 		add_action( 'admin_notices', [ $this, 'display_anomaly_notices' ] );
 		add_action( 'wp_ajax_dismiss_anomaly_notice', [ $this, 'dismiss_anomaly_notice' ] );

--- a/src/Admin/CachePerformance.php
+++ b/src/Admin/CachePerformance.php
@@ -30,7 +30,9 @@ class CachePerformance {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_init', [ $this, 'handle_actions' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 	}

--- a/src/Admin/ConversionEventsAdmin.php
+++ b/src/Admin/ConversionEventsAdmin.php
@@ -39,7 +39,9 @@ class ConversionEventsAdmin {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		add_action( 'admin_init', [ $this, 'handle_form_submission' ] );
 		add_action( 'wp_ajax_fp_conversion_event_action', [ $this, 'handle_ajax_request' ] );

--- a/src/Admin/Dashboard.php
+++ b/src/Admin/Dashboard.php
@@ -63,7 +63,9 @@ class Dashboard {
 
 		// Add admin hooks with error handling to prevent WSOD
 		try {
-			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+			if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+				add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+			}
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_dashboard_assets' ] );
 			add_action( 'wp_ajax_fp_dms_get_dashboard_data', [ $this, 'handle_ajax_dashboard_data' ] );
 			add_action( 'wp_ajax_fp_dms_get_chart_data', [ $this, 'handle_ajax_chart_data' ] );

--- a/src/Admin/FunnelAnalysisAdmin.php
+++ b/src/Admin/FunnelAnalysisAdmin.php
@@ -35,7 +35,9 @@ class FunnelAnalysisAdmin {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_init', [ $this, 'handle_funnel_actions' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
 		add_action( 'wp_ajax_fp_dms_get_funnel_data', [ $this, 'ajax_get_funnel_data' ] );
@@ -61,7 +63,7 @@ class FunnelAnalysisAdmin {
                add_submenu_page(
                        'fp-digital-marketing-dashboard',
 			__( 'Funnel Analysis', 'fp-digital-marketing' ),
-			__( 'Funnel Analysis', 'fp-digital-marketing' ),
+			__( '📈 Funnel Analysis', 'fp-digital-marketing' ),
 			Capabilities::FUNNEL_ANALYSIS,
 			self::PAGE_SLUG,
 			[ $this, 'render_admin_page' ]

--- a/src/Admin/MenuManager.php
+++ b/src/Admin/MenuManager.php
@@ -70,6 +70,8 @@ class MenuManager {
 
         /**
          * Returns the initialization state of the menu manager.
+         *
+         * @return bool
          */
         public static function is_initialized(): bool {
                 return self::$initialized;
@@ -103,8 +105,8 @@ class MenuManager {
 				],
 				[
 					'parent_slug' => self::MAIN_MENU_SLUG,
-					'page_title' => __( 'Analytics & Reports', 'fp-digital-marketing' ),
-					'menu_title' => __( '📊 Analytics & Reports', 'fp-digital-marketing' ),
+					'page_title' => __( 'Reports & Analytics', 'fp-digital-marketing' ),
+					'menu_title' => __( '📊 Reports', 'fp-digital-marketing' ),
 					'capability' => Capabilities::EXPORT_REPORTS,
 					'menu_slug' => 'fp-digital-marketing-reports',
 					'callback' => 'Reports::render_reports_page',
@@ -112,8 +114,17 @@ class MenuManager {
 				],
 				[
 					'parent_slug' => self::MAIN_MENU_SLUG,
-					'page_title' => __( 'Campaign Management', 'fp-digital-marketing' ),
-					'menu_title' => __( '🚀 Campaign Management', 'fp-digital-marketing' ),
+					'page_title' => __( 'Eventi Conversione', 'fp-digital-marketing' ),
+					'menu_title' => __( '🎯 Eventi Conversione', 'fp-digital-marketing' ),
+					'capability' => Capabilities::MANAGE_CONVERSIONS,
+					'menu_slug' => 'fp-conversion-events',
+					'callback' => 'ConversionEventsAdmin::render_admin_page',
+					'group' => 'analytics'
+				],
+				[
+					'parent_slug' => self::MAIN_MENU_SLUG,
+					'page_title' => __( 'Gestione Campagne UTM', 'fp-digital-marketing' ),
+					'menu_title' => __( '🚀 Campagne UTM', 'fp-digital-marketing' ),
 					'capability' => Capabilities::MANAGE_CAMPAIGNS,
 					'menu_slug' => 'fp-utm-campaign-manager',
 					'callback' => 'UTMCampaignManager::render_page',
@@ -122,16 +133,16 @@ class MenuManager {
 				[
 					'parent_slug' => self::MAIN_MENU_SLUG,
 					'page_title' => __( 'Funnel Analysis', 'fp-digital-marketing' ),
-					'menu_title' => __( '🎯 Funnel Analysis', 'fp-digital-marketing' ),
-					'capability' => Capabilities::VIEW_REPORTS,
+					'menu_title' => __( '📈 Funnel Analysis', 'fp-digital-marketing' ),
+					'capability' => Capabilities::FUNNEL_ANALYSIS,
 					'menu_slug' => 'fp-digital-marketing-funnel-analysis',
 					'callback' => 'FunnelAnalysisAdmin::render_admin_page',
 					'group' => 'campaigns'
 				],
 				[
 					'parent_slug' => self::MAIN_MENU_SLUG,
-					'page_title' => __( 'Audience Segmentation', 'fp-digital-marketing' ),
-					'menu_title' => __( '👥 Audience Segmentation', 'fp-digital-marketing' ),
+					'page_title' => __( 'Segmentazione Audience', 'fp-digital-marketing' ),
+					'menu_title' => __( '👥 Segmentazione', 'fp-digital-marketing' ),
 					'capability' => Capabilities::MANAGE_SEGMENTS,
 					'menu_slug' => 'fp-audience-segments',
 					'callback' => 'SegmentationAdmin::render_segmentation_page',
@@ -139,8 +150,8 @@ class MenuManager {
 				],
 				[
 					'parent_slug' => self::MAIN_MENU_SLUG,
-					'page_title' => __( 'Monitoring & Alerts', 'fp-digital-marketing' ),
-					'menu_title' => __( '🔔 Monitoring & Alerts', 'fp-digital-marketing' ),
+					'page_title' => __( 'Alert e Notifiche', 'fp-digital-marketing' ),
+					'menu_title' => __( '🔔 Alert e Notifiche', 'fp-digital-marketing' ),
 					'capability' => Capabilities::MANAGE_ALERTS,
 					'menu_slug' => 'fp-digital-marketing-alerts',
 					'callback' => 'AlertingAdmin::display_admin_page',
@@ -148,8 +159,8 @@ class MenuManager {
 				],
 				[
 					'parent_slug' => self::MAIN_MENU_SLUG,
-					'page_title' => __( 'Anomaly Detection', 'fp-digital-marketing' ),
-					'menu_title' => __( '🔍 Anomaly Detection', 'fp-digital-marketing' ),
+					'page_title' => __( 'Rilevazione Anomalie', 'fp-digital-marketing' ),
+					'menu_title' => __( '🔍 Rilevazione Anomalie', 'fp-digital-marketing' ),
 					'capability' => Capabilities::MANAGE_ALERTS,
 					'menu_slug' => 'fp-digital-marketing-anomalies',
 					'callback' => 'AnomalyDetectionAdmin::display_admin_page',
@@ -157,36 +168,36 @@ class MenuManager {
 				],
 				[
 					'parent_slug' => self::MAIN_MENU_SLUG,
-					'page_title' => __( 'Performance Cache', 'fp-digital-marketing' ),
-					'menu_title' => __( '⚡ Performance', 'fp-digital-marketing' ),
+					'page_title' => __( 'Cache Performance', 'fp-digital-marketing' ),
+					'menu_title' => __( '⚡ Cache Performance', 'fp-digital-marketing' ),
 					'capability' => Capabilities::MANAGE_SETTINGS,
 					'menu_slug' => 'fp-digital-marketing-cache-performance',
 					'callback' => 'CachePerformance::render_performance_page',
 					'group' => 'monitoring'
 				],
-                                [
-                                        'parent_slug' => self::MAIN_MENU_SLUG,
-                                        'page_title' => __( 'Security Settings', 'fp-digital-marketing' ),
-                                        'menu_title' => __( '🔒 Security', 'fp-digital-marketing' ),
-                                        'capability' => Capabilities::MANAGE_SETTINGS,
-                                        'menu_slug' => 'fp-digital-marketing-security',
-                                        'callback' => 'SecurityAdmin::render_security_page',
-                                        'group' => 'administration'
-                                ],
-                                [
-                                        'parent_slug' => self::MAIN_MENU_SLUG,
-                                        'page_title' => __( 'Platform Connections', 'fp-digital-marketing' ),
-                                        'menu_title' => __( '🔗 Platform Connections', 'fp-digital-marketing' ),
-                                        'capability' => Capabilities::MANAGE_SETTINGS,
-                                        'menu_slug' => 'fp-platform-connections',
-                                        'callback' => 'PlatformConnections::render_connections_page',
-                                        'group' => 'administration'
-                                ],
-                                [
-                                        'parent_slug' => self::MAIN_MENU_SLUG,
-                                        'page_title' => __( 'Settings', 'fp-digital-marketing' ),
-                                        'menu_title' => __( '⚙️ Settings', 'fp-digital-marketing' ),
-                                        'capability' => Capabilities::MANAGE_SETTINGS,
+				[
+					'parent_slug' => self::MAIN_MENU_SLUG,
+					'page_title' => __( 'Security Settings', 'fp-digital-marketing' ),
+					'menu_title' => __( '🔒 Security', 'fp-digital-marketing' ),
+					'capability' => Capabilities::MANAGE_SETTINGS,
+					'menu_slug' => 'fp-digital-marketing-security',
+					'callback' => 'SecurityAdmin::render_security_page',
+					'group' => 'administration'
+				],
+				[
+					'parent_slug' => self::MAIN_MENU_SLUG,
+					'page_title' => __( 'Connessioni Piattaforme', 'fp-digital-marketing' ),
+					'menu_title' => __( '🔗 Connessioni', 'fp-digital-marketing' ),
+					'capability' => Capabilities::MANAGE_SETTINGS,
+					'menu_slug' => 'fp-platform-connections',
+					'callback' => 'PlatformConnections::render_connections_page',
+					'group' => 'administration'
+				],
+				[
+					'parent_slug' => self::MAIN_MENU_SLUG,
+					'page_title' => __( 'FP Digital Marketing Settings', 'fp-digital-marketing' ),
+					'menu_title' => __( '⚙️ Settings', 'fp-digital-marketing' ),
+					'capability' => Capabilities::MANAGE_SETTINGS,
 					'menu_slug' => 'fp-digital-marketing-settings',
 					'callback' => 'Settings::render_settings_page',
 					'group' => 'administration'
@@ -194,14 +205,15 @@ class MenuManager {
 				[
 					'parent_slug' => self::MAIN_MENU_SLUG,
 					'page_title' => __( 'Setup Wizard', 'fp-digital-marketing' ),
-					'menu_title' => __( '🛠️ Setup Wizard', 'fp-digital-marketing' ),
-					'capability' => Capabilities::MANAGE_SETTINGS,
+					'menu_title' => __( '🚀 Setup Wizard', 'fp-digital-marketing' ),
+					'capability' => 'manage_options',
 					'menu_slug' => 'fp-digital-marketing-onboarding',
 					'callback' => 'OnboardingWizard::render_wizard_page',
 					'group' => 'administration'
 				]
 			]
 		];
+		self::$initialized = true;
 	}
 
 	/**
@@ -420,16 +432,17 @@ class MenuManager {
 	private function get_page_name_from_slug( string $slug ): string {
 		$page_names = [
 			'fp-digital-marketing-dashboard' => __( 'Dashboard', 'fp-digital-marketing' ),
-			'fp-digital-marketing-reports' => __( 'Analytics & Reports', 'fp-digital-marketing' ),
-			'fp-utm-campaign-manager' => __( 'Campaign Management', 'fp-digital-marketing' ),
+			'fp-digital-marketing-reports' => __( 'Reports & Analytics', 'fp-digital-marketing' ),
+			'fp-conversion-events' => __( 'Eventi Conversione', 'fp-digital-marketing' ),
+			'fp-utm-campaign-manager' => __( 'Gestione Campagne UTM', 'fp-digital-marketing' ),
 			'fp-digital-marketing-funnel-analysis' => __( 'Funnel Analysis', 'fp-digital-marketing' ),
-			'fp-audience-segments' => __( 'Audience Segmentation', 'fp-digital-marketing' ),
-			'fp-digital-marketing-alerts' => __( 'Monitoring & Alerts', 'fp-digital-marketing' ),
-			'fp-digital-marketing-anomalies' => __( 'Anomaly Detection', 'fp-digital-marketing' ),
-                        'fp-digital-marketing-cache-performance' => __( 'Performance Cache', 'fp-digital-marketing' ),
-                        'fp-digital-marketing-security' => __( 'Security Settings', 'fp-digital-marketing' ),
-                        'fp-platform-connections' => __( 'Platform Connections', 'fp-digital-marketing' ),
-                        'fp-digital-marketing-settings' => __( 'Settings', 'fp-digital-marketing' ),
+			'fp-audience-segments' => __( 'Segmentazione Audience', 'fp-digital-marketing' ),
+			'fp-digital-marketing-alerts' => __( 'Alert e Notifiche', 'fp-digital-marketing' ),
+			'fp-digital-marketing-anomalies' => __( 'Rilevazione Anomalie', 'fp-digital-marketing' ),
+			'fp-digital-marketing-cache-performance' => __( 'Cache Performance', 'fp-digital-marketing' ),
+			'fp-digital-marketing-security' => __( 'Security Settings', 'fp-digital-marketing' ),
+			'fp-platform-connections' => __( 'Connessioni Piattaforme', 'fp-digital-marketing' ),
+			'fp-digital-marketing-settings' => __( 'FP Digital Marketing Settings', 'fp-digital-marketing' ),
 			'fp-digital-marketing-onboarding' => __( 'Setup Wizard', 'fp-digital-marketing' ),
 		];
 		
@@ -542,6 +555,7 @@ class MenuManager {
 			'fp-digital-marketing-anomalies',
 			'fp-digital-marketing-utm-campaigns',
 			'fp-digital-marketing-conversion-events',
+			'fp-conversion-events',
 			'fp-digital-marketing-segments-old',
 			'fp-digital-marketing-cache',
 			'fp-digital-marketing-security-old'

--- a/src/Admin/OnboardingWizard.php
+++ b/src/Admin/OnboardingWizard.php
@@ -51,7 +51,9 @@ class OnboardingWizard {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_init', [ $this, 'handle_wizard_actions' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_wizard_scripts' ] );
 		add_action( 'admin_notices', [ $this, 'show_wizard_notice' ] );

--- a/src/Admin/PlatformConnections.php
+++ b/src/Admin/PlatformConnections.php
@@ -30,7 +30,9 @@ class PlatformConnections {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_scripts' ] );
 		add_action( 'admin_init', [ $this, 'handle_connection_actions' ] );
 		add_action( 'wp_ajax_fp_test_connection', [ $this, 'ajax_test_connection' ] );

--- a/src/Admin/Reports.php
+++ b/src/Admin/Reports.php
@@ -50,7 +50,9 @@ class Reports {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_init', [ $this, 'handle_report_actions' ] );
 	}
 

--- a/src/Admin/SecurityAdmin.php
+++ b/src/Admin/SecurityAdmin.php
@@ -29,7 +29,9 @@ class SecurityAdmin {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_init', [ $this, 'handle_security_actions' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_security_scripts' ] );
 	}

--- a/src/Admin/SegmentationAdmin.php
+++ b/src/Admin/SegmentationAdmin.php
@@ -40,7 +40,9 @@ class SegmentationAdmin {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		add_action( 'admin_init', [ $this, 'maybe_handle_get_actions' ], 5 );
 		add_action( 'admin_init', [ $this, 'handle_form_submission' ] );

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -141,7 +141,9 @@ class Settings {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_init', [ $this, 'handle_cache_actions' ] );
                 add_action( 'admin_init', [ $this, 'register_settings' ] );
                 add_action( 'admin_init', [ $this, 'handle_ga4_oauth_callback' ] );

--- a/src/Admin/UTMCampaignManager.php
+++ b/src/Admin/UTMCampaignManager.php
@@ -40,7 +40,9 @@ class UTMCampaignManager {
 	 * @return void
 	 */
 	public function init(): void {
-		add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		if ( ! ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) ) {
+			add_action( 'admin_menu', [ $this, 'add_admin_menu' ] );
+		}
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
 		add_action( 'admin_init', [ $this, 'handle_form_submission' ] );
 		add_action( 'wp_ajax_fp_utm_generate_url', [ $this, 'handle_ajax_generate_url' ] );
@@ -67,7 +69,7 @@ class UTMCampaignManager {
 		add_submenu_page(
 			'fp-digital-marketing-dashboard',
 			__( 'Gestione Campagne UTM', 'fp-digital-marketing' ),
-			__( '🔗 Campagne UTM', 'fp-digital-marketing' ),
+			__( '🚀 Campagne UTM', 'fp-digital-marketing' ),
 			Capabilities::MANAGE_CAMPAIGNS,
 			self::PAGE_SLUG,
 			[ $this, 'render_page' ]

--- a/src/DigitalMarketingSuite.php
+++ b/src/DigitalMarketingSuite.php
@@ -322,6 +322,7 @@ class DigitalMarketingSuite {
 				'Settings' => $this->settings,
 				'PlatformConnections' => $this->platform_connections,
 				'UTMCampaignManager' => $this->utm_campaign_manager,
+				'ConversionEventsAdmin' => $this->conversion_events_admin,
 				'FunnelAnalysisAdmin' => $this->funnel_analysis_admin,
 				'SegmentationAdmin' => $this->segmentation_admin,
 				'AlertingAdmin' => $this->alerting_admin,


### PR DESCRIPTION
## Summary
- guard each admin controller's fallback menu registration so it only fires when the centralized MenuManager has not initialized
- expand MenuManager's submenu configuration to cover conversion events, platform connections, and updated labels while tracking initialization state and cleaning legacy slugs
- pass ConversionEventsAdmin into the MenuManager instantiation and align legacy menu titles/icons with the centralized entries

## Testing
- php -l src/Admin/AlertingAdmin.php src/Admin/AnomalyDetectionAdmin.php src/Admin/CachePerformance.php src/Admin/ConversionEventsAdmin.php src/Admin/Dashboard.php src/Admin/FunnelAnalysisAdmin.php src/Admin/MenuManager.php src/Admin/OnboardingWizard.php src/Admin/PlatformConnections.php src/Admin/Reports.php src/Admin/SecurityAdmin.php src/Admin/SegmentationAdmin.php src/Admin/Settings.php src/Admin/UTMCampaignManager.php src/DigitalMarketingSuite.php

------
https://chatgpt.com/codex/tasks/task_e_68d305fd36fc832f85668e1c8aa902d8