### PR TITLE
Refine onboarding wizard state handling and OAuth flow

### DIFF
--- a/src/Admin/MenuManager.php
+++ b/src/Admin/MenuManager.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace FP\DigitalMarketing\Admin;
 
 use FP\DigitalMarketing\Helpers\Capabilities;
+use FP\DigitalMarketing\Setup\SettingsManager;
 
 /**
  * MenuManager class for centralized admin menu management
@@ -26,10 +27,22 @@ class MenuManager {
          */
         private static bool $initialized = false;
 
-	/**
-	 * Main menu slug
-	 */
-	private const MAIN_MENU_SLUG = 'fp-digital-marketing-dashboard';
+        /**
+         * Main menu slug
+         */
+        private const MAIN_MENU_SLUG = 'fp-digital-marketing-dashboard';
+
+        /**
+         * Setup wizard menu slug
+         */
+        private const WIZARD_MENU_SLUG = 'fp-digital-marketing-onboarding';
+
+        /**
+         * Singleton instance reference.
+         *
+         * @var MenuManager|null
+         */
+        private static ?MenuManager $instance = null;
 
 	/**
 	 * Menu structure configuration
@@ -50,10 +63,11 @@ class MenuManager {
 	 * 
 	 * @param array $admin_instances Pre-instantiated admin class instances
 	 */
-	public function __construct( array $admin_instances = [] ) {
-		$this->admin_instances = $admin_instances;
-		$this->define_menu_structure();
-	}
+        public function __construct( array $admin_instances = [] ) {
+                $this->admin_instances = $admin_instances;
+                self::$instance = $this;
+                $this->define_menu_structure();
+        }
 
 	/**
 	 * Initialize the menu manager
@@ -82,11 +96,11 @@ class MenuManager {
 	 *
 	 * @return void
 	 */
-	private function define_menu_structure(): void {
-		$this->menu_structure = [
-			'main' => [
-				'page_title' => __( 'FP Digital Marketing Suite', 'fp-digital-marketing' ),
-				'menu_title' => __( 'FP Digital Marketing', 'fp-digital-marketing' ),
+        private function define_menu_structure(): void {
+                $this->menu_structure = [
+                        'main' => [
+                                'page_title' => __( 'FP Digital Marketing Suite', 'fp-digital-marketing' ),
+                                'menu_title' => __( 'FP Digital Marketing', 'fp-digital-marketing' ),
 				'capability' => Capabilities::VIEW_DASHBOARD,
 				'menu_slug' => self::MAIN_MENU_SLUG,
 				'callback' => 'Dashboard::render_dashboard_page',
@@ -193,28 +207,96 @@ class MenuManager {
 					'callback' => 'PlatformConnections::render_connections_page',
 					'group' => 'administration'
 				],
-				[
-					'parent_slug' => self::MAIN_MENU_SLUG,
-					'page_title' => __( 'FP Digital Marketing Settings', 'fp-digital-marketing' ),
-					'menu_title' => __( '⚙️ Settings', 'fp-digital-marketing' ),
-					'capability' => Capabilities::MANAGE_SETTINGS,
-					'menu_slug' => 'fp-digital-marketing-settings',
-					'callback' => 'Settings::render_settings_page',
-					'group' => 'administration'
-				],
-				[
-					'parent_slug' => self::MAIN_MENU_SLUG,
-					'page_title' => __( 'Setup Wizard', 'fp-digital-marketing' ),
-					'menu_title' => __( '🚀 Setup Wizard', 'fp-digital-marketing' ),
-					'capability' => 'manage_options',
-					'menu_slug' => 'fp-digital-marketing-onboarding',
-					'callback' => 'OnboardingWizard::render_wizard_page',
-					'group' => 'administration'
-				]
-			]
-		];
-		self::$initialized = true;
-	}
+                                [
+                                        'parent_slug' => self::MAIN_MENU_SLUG,
+                                        'page_title' => __( 'FP Digital Marketing Settings', 'fp-digital-marketing' ),
+                                        'menu_title' => __( '⚙️ Settings', 'fp-digital-marketing' ),
+                                        'capability' => Capabilities::MANAGE_SETTINGS,
+                                        'menu_slug' => 'fp-digital-marketing-settings',
+                                        'callback' => 'Settings::render_settings_page',
+                                        'group' => 'administration'
+                                ]
+                        ]
+                ];
+
+                if ( SettingsManager::is_wizard_menu_enabled() ) {
+                        $this->menu_structure['submenus'][] = $this->get_wizard_menu_config();
+                }
+
+                $this->persist_menu_slugs();
+                self::$initialized = true;
+        }
+
+        /**
+         * Get the configuration array for the wizard menu item.
+         *
+         * @return array
+         */
+        private function get_wizard_menu_config(): array {
+                return [
+                        'parent_slug' => self::MAIN_MENU_SLUG,
+                        'page_title' => __( 'Setup Wizard', 'fp-digital-marketing' ),
+                        'menu_title' => __( '🚀 Setup Wizard', 'fp-digital-marketing' ),
+                        'capability' => Capabilities::MANAGE_SETTINGS,
+                        'menu_slug' => self::WIZARD_MENU_SLUG,
+                        'callback' => 'OnboardingWizard::render_wizard_page',
+                        'group' => 'administration',
+                ];
+        }
+
+        /**
+         * Persist the currently registered menu slugs.
+         *
+         * @return void
+         */
+        private function persist_menu_slugs(): void {
+                $slugs = [];
+
+                if ( isset( $this->menu_structure['main']['menu_slug'] ) ) {
+                        $slugs[] = (string) $this->menu_structure['main']['menu_slug'];
+                }
+
+                foreach ( $this->menu_structure['submenus'] as $submenu ) {
+                        if ( isset( $submenu['menu_slug'] ) ) {
+                                $slugs[] = (string) $submenu['menu_slug'];
+                        }
+                }
+
+                SettingsManager::set_registered_menu_slugs( $slugs );
+        }
+
+        /**
+         * Remove the wizard menu entry from the internal structure.
+         *
+         * @return void
+         */
+        private function remove_wizard_menu_from_structure(): void {
+                if ( empty( $this->menu_structure['submenus'] ) ) {
+                        return;
+                }
+
+                $this->menu_structure['submenus'] = array_values( array_filter(
+                        $this->menu_structure['submenus'],
+                        static function ( array $menu ): bool {
+                                return ( $menu['menu_slug'] ?? '' ) !== self::WIZARD_MENU_SLUG;
+                        }
+                ) );
+        }
+
+        /**
+         * Ensure the wizard menu entry exists in the internal structure.
+         *
+         * @return void
+         */
+        private function add_wizard_menu_to_structure(): void {
+                foreach ( $this->menu_structure['submenus'] as $menu ) {
+                        if ( isset( $menu['menu_slug'] ) && $menu['menu_slug'] === self::WIZARD_MENU_SLUG ) {
+                                return;
+                        }
+                }
+
+                $this->menu_structure['submenus'][] = $this->get_wizard_menu_config();
+        }
 
 	/**
 	 * Register all menus according to the rationalized structure
@@ -522,11 +604,11 @@ class MenuManager {
 	 *
 	 * @return void
 	 */
-	public function handle_dismiss_notice(): void {
-		// Verify nonce
-		if ( ! wp_verify_nonce( $_POST['nonce'] ?? '', 'fp_dms_dismiss_notice' ) ) {
-			wp_die( 'Security check failed' );
-		}
+        public function handle_dismiss_notice(): void {
+                // Verify nonce
+                if ( ! wp_verify_nonce( $_POST['nonce'] ?? '', 'fp_dms_dismiss_notice' ) ) {
+                        wp_die( 'Security check failed' );
+                }
 
 		// Check user capability
 		if ( ! current_user_can( 'manage_options' ) ) {
@@ -537,13 +619,56 @@ class MenuManager {
 		$user_id = get_current_user_id();
 		update_user_meta( $user_id, 'fp_dms_menu_rationalization_notice_dismissed', true );
 
-		wp_send_json_success();
-	}
+                wp_send_json_success();
+        }
 
-	/**
-	 * Remove legacy menu items to prevent duplicates
-	 * 
-	 * This method should be called to clean up old menu registrations
+        /**
+         * Disable the setup wizard menu entry and update stored menu state.
+         *
+         * @param string $status Wizard completion status.
+         * @return void
+         */
+        public static function disable_wizard_menu_entry( string $status = 'completed' ): void {
+                SettingsManager::disable_wizard_menu( self::WIZARD_MENU_SLUG, $status );
+
+                if ( self::$instance instanceof self ) {
+                        self::$instance->remove_wizard_menu_from_structure();
+                        self::$instance->persist_menu_slugs();
+                } else {
+                        SettingsManager::remove_registered_menu_slug( self::WIZARD_MENU_SLUG );
+                }
+
+                global $submenu;
+
+                if ( isset( $submenu[ self::MAIN_MENU_SLUG ] ) && is_array( $submenu[ self::MAIN_MENU_SLUG ] ) ) {
+                        foreach ( $submenu[ self::MAIN_MENU_SLUG ] as $index => $menu ) {
+                                if ( isset( $menu[2] ) && $menu[2] === self::WIZARD_MENU_SLUG ) {
+                                        unset( $submenu[ self::MAIN_MENU_SLUG ][ $index ] );
+                                }
+                        }
+
+                        $submenu[ self::MAIN_MENU_SLUG ] = array_values( $submenu[ self::MAIN_MENU_SLUG ] );
+                }
+        }
+
+        /**
+         * Enable the setup wizard menu entry for subsequent requests.
+         *
+         * @return void
+         */
+        public static function enable_wizard_menu_entry(): void {
+                SettingsManager::enable_wizard_menu( self::WIZARD_MENU_SLUG );
+
+                if ( self::$instance instanceof self ) {
+                        self::$instance->add_wizard_menu_to_structure();
+                        self::$instance->persist_menu_slugs();
+                }
+        }
+
+        /**
+         * Remove legacy menu items to prevent duplicates
+         *
+         * This method should be called to clean up old menu registrations
 	 *
 	 * @return void
 	 */

--- a/src/Admin/OnboardingWizard.php
+++ b/src/Admin/OnboardingWizard.php
@@ -11,9 +11,11 @@ namespace FP\DigitalMarketing\Admin;
 
 use FP\DigitalMarketing\DataSources\GoogleOAuth;
 use FP\DigitalMarketing\DataSources\GoogleAnalytics4;
+use FP\DigitalMarketing\Helpers\Capabilities;
 use FP\DigitalMarketing\Helpers\DataSources;
 use FP\DigitalMarketing\Helpers\MetricsSchema;
 use FP\DigitalMarketing\Helpers\Security;
+use FP\DigitalMarketing\Setup\SettingsManager;
 
 /**
  * Onboarding Wizard class for first-time setup
@@ -23,27 +25,44 @@ class OnboardingWizard {
 	/**
 	 * Page slug for the wizard
 	 */
-	private const PAGE_SLUG = 'fp-digital-marketing-onboarding';
+        public const PAGE_SLUG = 'fp-digital-marketing-onboarding';
 
-	/**
-	 * Option name for wizard progress
-	 */
-	private const WIZARD_PROGRESS_OPTION = 'fp_digital_marketing_wizard_progress';
+        /**
+         * Option name for wizard progress
+         */
+        private const WIZARD_PROGRESS_OPTION = SettingsManager::OPTION_WIZARD_PROGRESS;
 
-	/**
-	 * Option name for wizard completion status
-	 */
-	private const WIZARD_COMPLETED_OPTION = 'fp_digital_marketing_wizard_completed';
+        /**
+         * Option name for wizard completion status
+         */
+        private const WIZARD_COMPLETED_OPTION = SettingsManager::OPTION_WIZARD_COMPLETED;
 
 	/**
 	 * Nonce action for wizard forms
 	 */
 	private const NONCE_ACTION = 'fp_digital_marketing_wizard_nonce';
 
-	/**
-	 * Total number of wizard steps
-	 */
-	private const TOTAL_STEPS = 5;
+        /**
+         * Total number of wizard steps
+         */
+        private const TOTAL_STEPS = 5;
+
+        /**
+         * Determine whether the current user can access wizard management actions.
+         *
+         * @return bool
+         */
+        private function current_user_can_manage_wizard(): bool {
+                if ( class_exists( Capabilities::class ) ) {
+                        return Capabilities::current_user_can( Capabilities::MANAGE_SETTINGS );
+                }
+
+                if ( function_exists( 'current_user_can' ) ) {
+                        return current_user_can( 'manage_options' );
+                }
+
+                return true;
+        }
 
 	/**
 	 * Initialize the onboarding wizard
@@ -63,13 +82,22 @@ class OnboardingWizard {
 	 * Add admin menu page for the wizard
 	 *
 	 * @return void
-	 */
+        */
         public function add_admin_menu(): void {
                 if ( class_exists( MenuManager::class ) && MenuManager::is_initialized() ) {
                         return;
                 }
 
-                // Always add as submenu under main menu, regardless of completion status
+                if ( ! SettingsManager::is_wizard_menu_enabled() ) {
+                        return;
+                }
+
+                $registered_slugs = SettingsManager::get_registered_menu_slugs();
+                if ( ! in_array( self::PAGE_SLUG, $registered_slugs, true ) ) {
+                        SettingsManager::enable_wizard_menu( self::PAGE_SLUG );
+                }
+
+                // Register fallback submenu under the main menu when the wizard is enabled
                 add_submenu_page(
                         'fp-digital-marketing-dashboard',
                         __( 'Setup Wizard', 'fp-digital-marketing' ),
@@ -86,9 +114,17 @@ class OnboardingWizard {
 	 * @return void
 	 */
 	public function show_wizard_notice(): void {
-		if ( get_option( self::WIZARD_COMPLETED_OPTION, false ) ) {
-			return;
-		}
+                if ( ! $this->current_user_can_manage_wizard() ) {
+                        return;
+                }
+
+                if ( SettingsManager::get_option( self::WIZARD_COMPLETED_OPTION, false ) ) {
+                        return;
+                }
+
+                if ( ! function_exists( 'get_current_screen' ) ) {
+                        return;
+                }
 
                 $screen = get_current_screen();
                 if ( ! $screen ) {
@@ -121,9 +157,18 @@ class OnboardingWizard {
 			return;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( esc_html__( 'Non autorizzato', 'fp-digital-marketing' ) );
-		}
+                if ( ! $this->current_user_can_manage_wizard() ) {
+                        $user_id = function_exists( 'get_current_user_id' ) ? get_current_user_id() : 0;
+                        Security::log_security_event(
+                                'wizard_access_denied',
+                                [
+                                        'user_id' => $user_id,
+                                        'page' => self::PAGE_SLUG,
+                                ]
+                        );
+
+                        wp_die( esc_html__( 'Non autorizzato', 'fp-digital-marketing' ) );
+                }
 
 		// Handle POST requests
 		if ( $_SERVER['REQUEST_METHOD'] === 'POST' ) {
@@ -182,7 +227,7 @@ class OnboardingWizard {
 	 * @return void
 	 */
 	private function process_step_data( int $step ): void {
-		$progress = get_option( self::WIZARD_PROGRESS_OPTION, [] );
+                $progress = SettingsManager::get_option( self::WIZARD_PROGRESS_OPTION, [] );
 
 		switch ( $step ) {
 			case 1:
@@ -222,7 +267,7 @@ class OnboardingWizard {
 				break;
 		}
 
-		update_option( self::WIZARD_PROGRESS_OPTION, $progress );
+                SettingsManager::update_option( self::WIZARD_PROGRESS_OPTION, $progress );
 	}
 
 	/**
@@ -244,7 +289,7 @@ class OnboardingWizard {
 	 * @return void
 	 */
 	private function complete_wizard(): void {
-		$progress = get_option( self::WIZARD_PROGRESS_OPTION, [] );
+                $progress = SettingsManager::get_option( self::WIZARD_PROGRESS_OPTION, [] );
 
 		// Apply service connections
 		if ( ! empty( $progress['services'] ) ) {
@@ -266,14 +311,19 @@ class OnboardingWizard {
 			$this->save_user_feedback( $progress['feedback'] );
 		}
 
-		// Mark wizard as completed
-		update_option( self::WIZARD_COMPLETED_OPTION, true );
-		delete_option( self::WIZARD_PROGRESS_OPTION );
+                // Mark wizard as completed
+                SettingsManager::update_option( self::WIZARD_COMPLETED_OPTION, true );
+                SettingsManager::delete_option( self::WIZARD_PROGRESS_OPTION );
+                if ( class_exists( MenuManager::class ) ) {
+                        MenuManager::disable_wizard_menu_entry( 'completed' );
+                } else {
+                        SettingsManager::disable_wizard_menu( self::PAGE_SLUG, 'completed' );
+                }
 
-		// Redirect to success page
-		$url = admin_url( 'admin.php?page=' . self::PAGE_SLUG . '&completed=1' );
-		wp_redirect( $url );
-		exit;
+                // Redirect to success page
+                $url = admin_url( 'admin.php?page=' . self::PAGE_SLUG . '&completed=1' );
+                wp_redirect( $url );
+                exit;
 	}
 
 	/**
@@ -281,13 +331,19 @@ class OnboardingWizard {
 	 *
 	 * @return void
 	 */
-	private function skip_wizard(): void {
-		update_option( self::WIZARD_COMPLETED_OPTION, true );
-		delete_option( self::WIZARD_PROGRESS_OPTION );
+        private function skip_wizard(): void {
+                SettingsManager::update_option( self::WIZARD_COMPLETED_OPTION, true );
+                SettingsManager::delete_option( self::WIZARD_PROGRESS_OPTION );
+
+                if ( class_exists( MenuManager::class ) ) {
+                        MenuManager::disable_wizard_menu_entry( 'skipped' );
+                } else {
+                        SettingsManager::disable_wizard_menu( self::PAGE_SLUG, 'skipped' );
+                }
 
                 // Redirect to main dashboard page
                 $url = admin_url( 'admin.php?page=fp-digital-marketing-dashboard' );
-		wp_redirect( $url );
+                wp_redirect( $url );
 		exit;
 	}
 
@@ -298,7 +354,7 @@ class OnboardingWizard {
 	 * @return void
 	 */
 	private function apply_service_settings( array $services ): void {
-		$api_keys = get_option( 'fp_digital_marketing_api_keys', [] );
+                $api_keys = SettingsManager::get_option( SettingsManager::OPTION_API_KEYS, [] );
 
 		foreach ( $services as $service ) {
 			if ( $service === 'google_analytics_4' ) {
@@ -307,7 +363,7 @@ class OnboardingWizard {
 			}
 		}
 
-		update_option( 'fp_digital_marketing_api_keys', $api_keys );
+                SettingsManager::update_option( SettingsManager::OPTION_API_KEYS, $api_keys );
 	}
 
 	/**
@@ -317,9 +373,9 @@ class OnboardingWizard {
 	 * @return void
 	 */
 	private function apply_metric_settings( array $metrics ): void {
-		$sync_settings = get_option( 'fp_digital_marketing_sync_settings', [] );
-		$sync_settings['enabled_metrics'] = $metrics;
-		update_option( 'fp_digital_marketing_sync_settings', $sync_settings );
+                $sync_settings = SettingsManager::get_option( SettingsManager::OPTION_SYNC_SETTINGS, [] );
+                $sync_settings['enabled_metrics'] = $metrics;
+                SettingsManager::update_option( SettingsManager::OPTION_SYNC_SETTINGS, $sync_settings );
 	}
 
 	/**
@@ -331,7 +387,7 @@ class OnboardingWizard {
 	private function apply_report_settings( array $report_config ): void {
 		// This would integrate with the existing ReportScheduler
 		// For now, we'll save the settings for future use
-		update_option( 'fp_digital_marketing_report_config', $report_config );
+                SettingsManager::update_option( SettingsManager::OPTION_REPORT_CONFIG, $report_config );
 	}
 
 	/**
@@ -341,12 +397,12 @@ class OnboardingWizard {
 	 * @return void
 	 */
 	private function save_user_feedback( array $feedback ): void {
-		$existing_feedback = get_option( 'fp_digital_marketing_user_feedback', [] );
-		$existing_feedback[] = array_merge( $feedback, [
-			'timestamp' => current_time( 'mysql' ),
-			'user_id' => get_current_user_id(),
-		] );
-		update_option( 'fp_digital_marketing_user_feedback', $existing_feedback );
+                $existing_feedback = SettingsManager::get_option( SettingsManager::OPTION_USER_FEEDBACK, [] );
+                $existing_feedback[] = array_merge( $feedback, [
+                        'timestamp' => current_time( 'mysql' ),
+                        'user_id' => get_current_user_id(),
+                ] );
+                SettingsManager::update_option( SettingsManager::OPTION_USER_FEEDBACK, $existing_feedback );
 	}
 
 	/**
@@ -359,7 +415,7 @@ class OnboardingWizard {
 		$step = max( 1, min( $step, self::TOTAL_STEPS ) );
 
 		$state = sanitize_text_field( wp_unslash( $_GET['state'] ?? '' ) );
-		$stored_state = get_option( 'fp_dms_oauth_state', '' );
+                $stored_state = SettingsManager::get_option( SettingsManager::OPTION_OAUTH_STATE, '' );
 
 		if ( empty( $state ) || ! wp_verify_nonce( $state, 'ga4_oauth_state' ) || $state !== $stored_state ) {
 			error_log( sprintf(
@@ -379,7 +435,7 @@ class OnboardingWizard {
 			return;
 		}
 
-		delete_option( 'fp_dms_oauth_state' );
+                SettingsManager::delete_option( SettingsManager::OPTION_OAUTH_STATE );
 
 		if ( isset( $_GET['error'] ) ) {
 			$oauth_error = sanitize_text_field( wp_unslash( $_GET['error'] ) );
@@ -479,15 +535,42 @@ class OnboardingWizard {
 	 * @return void
 	 */
         public function enqueue_wizard_scripts( string $hook ): void {
-                if ( strpos( $hook, self::PAGE_SLUG ) === false ) {
+                if ( ! function_exists( 'get_current_screen' ) ) {
                         return;
                 }
 
-		wp_enqueue_script( 'jquery' );
-		
-		wp_add_inline_style( 'wp-admin', $this->get_wizard_css() );
-		wp_add_inline_script( 'jquery', $this->get_wizard_js() );
-	}
+                $screen = get_current_screen();
+
+                if ( ! $this->is_wizard_screen( $screen ) ) {
+                        return;
+                }
+
+                wp_enqueue_script( 'jquery' );
+
+                wp_add_inline_style( 'wp-admin', $this->get_wizard_css() );
+                wp_add_inline_script( 'jquery', $this->get_wizard_js() );
+        }
+
+        /**
+         * Determine if the given admin screen corresponds to the wizard page.
+         *
+         * @param mixed $screen Current screen object.
+         * @return bool True when the wizard assets should load.
+         */
+        private function is_wizard_screen( $screen ): bool {
+                if ( ! is_object( $screen ) || ! isset( $screen->id ) ) {
+                        return false;
+                }
+
+                $screen_id = (string) $screen->id;
+                $expected_ids = [
+                        'fp-digital-marketing-dashboard_page_' . self::PAGE_SLUG,
+                        'fp-digital-marketing_page_' . self::PAGE_SLUG,
+                        'toplevel_page_' . self::PAGE_SLUG,
+                ];
+
+                return in_array( $screen_id, $expected_ids, true );
+        }
 
 	/**
 	 * Get wizard CSS styles
@@ -664,14 +747,18 @@ class OnboardingWizard {
 		';
 	}
 
-	/**
-	 * Render the main wizard page
-	 *
-	 * @return void
-	 */
-	public function render_wizard_page(): void {
-		$current_step = intval( $_GET['step'] ?? 1 );
-		$current_step = max( 1, min( $current_step, self::TOTAL_STEPS ) );
+        /**
+         * Render the main wizard page
+         *
+         * @return void
+         */
+        public function render_wizard_page(): void {
+                if ( ! $this->current_user_can_manage_wizard() ) {
+                        wp_die( esc_html__( 'Non autorizzato', 'fp-digital-marketing' ) );
+                }
+
+                $current_step = intval( $_GET['step'] ?? 1 );
+                $current_step = max( 1, min( $current_step, self::TOTAL_STEPS ) );
 
 		// Check if wizard was just completed
 		if ( isset( $_GET['completed'] ) ) {
@@ -802,7 +889,7 @@ class OnboardingWizard {
 		echo '<h2>' . esc_html__( 'Connect Your Services', 'fp-digital-marketing' ) . '</h2>';
 		echo '<p>' . esc_html__( 'Select the services you want to connect to track your digital marketing performance.', 'fp-digital-marketing' ) . '</p>';
 
-		$progress = get_option( self::WIZARD_PROGRESS_OPTION, [] );
+                $progress = SettingsManager::get_option( self::WIZARD_PROGRESS_OPTION, [] );
 		$selected_services = $progress['services'] ?? [];
 
 		// Get available data sources
@@ -847,7 +934,7 @@ class OnboardingWizard {
 		echo '<h2>' . esc_html__( 'Choose Your Metrics', 'fp-digital-marketing' ) . '</h2>';
 		echo '<p>' . esc_html__( 'Select the metrics you want to track. You can always change these later in the settings.', 'fp-digital-marketing' ) . '</p>';
 
-		$progress = get_option( self::WIZARD_PROGRESS_OPTION, [] );
+                $progress = SettingsManager::get_option( self::WIZARD_PROGRESS_OPTION, [] );
 		$selected_metrics = $progress['metrics'] ?? [];
 
 		// Get available metrics from schema
@@ -892,7 +979,7 @@ class OnboardingWizard {
 		echo '<h2>' . esc_html__( 'Configure Reports', 'fp-digital-marketing' ) . '</h2>';
 		echo '<p>' . esc_html__( 'Set up how often you want to receive automated reports and where to send them.', 'fp-digital-marketing' ) . '</p>';
 
-		$progress = get_option( self::WIZARD_PROGRESS_OPTION, [] );
+                $progress = SettingsManager::get_option( self::WIZARD_PROGRESS_OPTION, [] );
 		$report_config = $progress['reports'] ?? [];
 
 		echo '<table class="form-table">';
@@ -945,7 +1032,7 @@ class OnboardingWizard {
 		echo '<h2>' . esc_html__( 'Almost Done!', 'fp-digital-marketing' ) . '</h2>';
 		echo '<p>' . esc_html__( 'Help us improve the setup experience by sharing your feedback.', 'fp-digital-marketing' ) . '</p>';
 
-		$progress = get_option( self::WIZARD_PROGRESS_OPTION, [] );
+                $progress = SettingsManager::get_option( self::WIZARD_PROGRESS_OPTION, [] );
 		$feedback = $progress['feedback'] ?? [];
 
 		echo '<table class="form-table">';
@@ -1063,7 +1150,7 @@ class OnboardingWizard {
 	 * @return bool True if wizard is completed.
 	 */
 	public static function is_completed(): bool {
-		return (bool) get_option( self::WIZARD_COMPLETED_OPTION, false );
+                return (bool) SettingsManager::get_option( self::WIZARD_COMPLETED_OPTION, false );
 	}
 
 	/**
@@ -1072,7 +1159,13 @@ class OnboardingWizard {
 	 * @return void
 	 */
 	public static function reset(): void {
-		delete_option( self::WIZARD_COMPLETED_OPTION );
-		delete_option( self::WIZARD_PROGRESS_OPTION );
-	}
+                SettingsManager::delete_option( self::WIZARD_COMPLETED_OPTION );
+                SettingsManager::delete_option( self::WIZARD_PROGRESS_OPTION );
+
+                SettingsManager::enable_wizard_menu( self::PAGE_SLUG );
+
+                if ( class_exists( MenuManager::class ) ) {
+                        MenuManager::enable_wizard_menu_entry();
+                }
+        }
 }

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -20,6 +20,7 @@ use FP\DigitalMarketing\Helpers\PerformanceCache;
 use FP\DigitalMarketing\Helpers\XmlSitemap;
 use FP\DigitalMarketing\Helpers\SchemaGenerator;
 use FP\DigitalMarketing\Helpers\Capabilities;
+use FP\DigitalMarketing\Setup\SettingsManager;
 
 /**
  * Settings class for plugin administration
@@ -1045,7 +1046,7 @@ class Settings {
 
 			// Verify state parameter with enhanced security
 			$state = sanitize_text_field( wp_unslash( $_GET['state'] ?? '' ) );
-			$stored_state = get_option( 'fp_dms_oauth_state', '' );
+                        $stored_state = SettingsManager::get_option( SettingsManager::OPTION_OAUTH_STATE, '' );
 			
 			// Enhanced nonce verification
 			if ( ! wp_verify_nonce( $state, 'ga4_oauth_state' ) || $state !== $stored_state ) {
@@ -1066,7 +1067,7 @@ class Settings {
 			}
 
 			// Clean up state
-			delete_option( 'fp_dms_oauth_state' );
+                        SettingsManager::delete_option( SettingsManager::OPTION_OAUTH_STATE );
 
 			if ( isset( $_GET['code'] ) ) {
 				$oauth = new GoogleOAuth();

--- a/src/DataSources/GoogleOAuth.php
+++ b/src/DataSources/GoogleOAuth.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace FP\DigitalMarketing\DataSources;
 
 use FP\DigitalMarketing\Helpers\Security;
+use FP\DigitalMarketing\Setup\SettingsManager;
 
 /**
  * Google OAuth client for handling authentication
@@ -52,12 +53,12 @@ class GoogleOAuth {
 	/**
 	 * Option name for storing tokens
 	 */
-	private const TOKEN_OPTION = 'fp_dms_google_oauth_tokens';
+        private const TOKEN_OPTION = SettingsManager::OPTION_GOOGLE_OAUTH_TOKENS;
 
 	/**
 	 * Option name for storing OAuth settings
 	 */
-	private const OAUTH_SETTINGS_OPTION = 'fp_dms_google_oauth_settings';
+        private const OAUTH_SETTINGS_OPTION = SettingsManager::OPTION_GOOGLE_OAUTH_SETTINGS;
 
 	/**
 	 * Client credentials
@@ -79,7 +80,7 @@ class GoogleOAuth {
 	 * @return array OAuth credentials
 	 */
         private function get_oauth_credentials(): array {
-                $api_keys = get_option( 'fp_digital_marketing_api_keys', [] );
+                $api_keys = SettingsManager::get_option( SettingsManager::OPTION_API_KEYS, [] );
 
                 $client_id = $api_keys['google_client_id'] ?? '';
                 $raw_client_secret = $api_keys['google_client_secret'] ?? '';
@@ -118,7 +119,7 @@ class GoogleOAuth {
 		}
 
 		$state = wp_create_nonce( 'ga4_oauth_state' );
-		update_option( 'fp_dms_oauth_state', $state );
+                SettingsManager::update_option( SettingsManager::OPTION_OAUTH_STATE, $state );
 
 		$params = [
 			'client_id' => $this->credentials['client_id'],
@@ -139,42 +140,70 @@ class GoogleOAuth {
 	 * @param string $authorization_code Authorization code from Google
 	 * @return bool True on success, false on failure
 	 */
-	public function exchange_code_for_tokens( string $authorization_code ): bool {
-		if ( ! $this->is_configured() ) {
-			return false;
-		}
+        public function exchange_code_for_tokens( string $authorization_code ): bool {
+                if ( ! $this->is_configured() ) {
+                        return false;
+                }
 
-		$data = [
-			'client_id' => $this->credentials['client_id'],
-			'client_secret' => $this->credentials['client_secret'],
-			'redirect_uri' => $this->credentials['redirect_uri'],
-			'grant_type' => 'authorization_code',
-			'code' => $authorization_code,
-		];
+                $data = [
+                        'client_id' => $this->credentials['client_id'],
+                        'client_secret' => $this->credentials['client_secret'],
+                        'redirect_uri' => $this->credentials['redirect_uri'],
+                        'grant_type' => 'authorization_code',
+                        'code' => $authorization_code,
+                ];
 
-		$response = wp_remote_post( self::TOKEN_URL, [
-			'body' => $data,
-			'headers' => [
-				'Content-Type' => 'application/x-www-form-urlencoded',
-			],
-		] );
+                $response = wp_remote_post( self::TOKEN_URL, [
+                        'body' => $data,
+                        'headers' => [
+                                'Content-Type' => 'application/x-www-form-urlencoded',
+                        ],
+                        'timeout' => 20,
+                ] );
 
-		if ( is_wp_error( $response ) ) {
-			error_log( 'GA4 OAuth token exchange error: ' . $response->get_error_message() );
-			return false;
-		}
+                if ( is_wp_error( $response ) ) {
+                        if ( function_exists( 'error_log' ) ) {
+                                error_log( 'GA4 OAuth token exchange error: ' . $response->get_error_message() );
+                        }
+                        return false;
+                }
 
-		$body = wp_remote_retrieve_body( $response );
-		$tokens = json_decode( $body, true );
+                $status_code = wp_remote_retrieve_response_code( $response );
+                $body = wp_remote_retrieve_body( $response );
 
-		if ( isset( $tokens['access_token'] ) ) {
-			$this->store_tokens( $tokens );
-			return true;
-		}
+                if ( 200 !== $status_code ) {
+                        if ( function_exists( 'error_log' ) ) {
+                                error_log( sprintf( 'GA4 OAuth token exchange HTTP %d: %s', $status_code, $body ) );
+                        }
+                        return false;
+                }
 
-		error_log( 'GA4 OAuth token exchange failed: ' . $body );
-		return false;
-	}
+                $tokens = json_decode( $body, true );
+
+                if ( ! is_array( $tokens ) ) {
+                        if ( function_exists( 'error_log' ) ) {
+                                error_log( 'GA4 OAuth token exchange returned invalid JSON.' );
+                        }
+                        return false;
+                }
+
+                if ( empty( $tokens['access_token'] ) ) {
+                        if ( function_exists( 'error_log' ) ) {
+                                $error_message = isset( $tokens['error'] ) ? $tokens['error'] : 'missing access token';
+                                error_log( 'GA4 OAuth token exchange failed: ' . $error_message );
+                        }
+                        return false;
+                }
+
+                $existing_tokens = $this->get_stored_tokens();
+                if ( empty( $tokens['refresh_token'] ) && is_array( $existing_tokens ) && ! empty( $existing_tokens['refresh_token'] ) ) {
+                        $tokens['refresh_token'] = $existing_tokens['refresh_token'];
+                }
+
+                $this->store_tokens( $tokens );
+
+                return true;
+        }
 
 	/**
 	 * Store tokens securely with encryption
@@ -182,17 +211,29 @@ class GoogleOAuth {
 	 * @param array $tokens Token data from Google
 	 * @return void
 	 */
-	private function store_tokens( array $tokens ): void {
-		$token_data = [
-			'access_token' => Security::encrypt_sensitive_data( $tokens['access_token'] ),
-			'refresh_token' => isset( $tokens['refresh_token'] ) ? Security::encrypt_sensitive_data( $tokens['refresh_token'] ) : '',
-			'expires_in' => $tokens['expires_in'] ?? 3600,
-			'token_type' => $tokens['token_type'] ?? 'Bearer',
-			'created_at' => time(),
-		];
+        private function store_tokens( array $tokens ): void {
+                $existing_tokens = $this->get_stored_tokens();
 
-		update_option( self::TOKEN_OPTION, $token_data, false ); // autoload = false for security
-	}
+                $refresh_token = $tokens['refresh_token'] ?? '';
+                if ( '' === $refresh_token && is_array( $existing_tokens ) && ! empty( $existing_tokens['refresh_token'] ) ) {
+                        $refresh_token = $existing_tokens['refresh_token'];
+                }
+
+                $expires_in = isset( $tokens['expires_in'] ) ? (int) $tokens['expires_in'] : null;
+                if ( null === $expires_in && is_array( $existing_tokens ) && isset( $existing_tokens['expires_in'] ) ) {
+                        $expires_in = (int) $existing_tokens['expires_in'];
+                }
+
+                $token_data = [
+                        'access_token' => Security::encrypt_sensitive_data( $tokens['access_token'] ),
+                        'refresh_token' => $refresh_token !== '' ? Security::encrypt_sensitive_data( $refresh_token ) : '',
+                        'expires_in' => $expires_in ?? 3600,
+                        'token_type' => $tokens['token_type'] ?? ( $existing_tokens['token_type'] ?? 'Bearer' ),
+                        'created_at' => time(),
+                ];
+
+                SettingsManager::update_option( self::TOKEN_OPTION, $token_data, false ); // autoload = false for security
+        }
 
 	/**
 	 * Get stored tokens with decryption
@@ -200,23 +241,26 @@ class GoogleOAuth {
 	 * @return array|false Token data with decrypted sensitive values or false if not found
 	 */
 	private function get_stored_tokens(): array|false {
-		$tokens = get_option( self::TOKEN_OPTION, false );
-		
-		if ( ! $tokens ) {
-			return false;
-		}
+                $tokens = SettingsManager::get_option( self::TOKEN_OPTION, [] );
 
-		// Decrypt sensitive token data
-		$decrypted_tokens = [
-			'access_token' => Security::decrypt_sensitive_data( $tokens['access_token'] ),
-			'refresh_token' => ! empty( $tokens['refresh_token'] ) ? Security::decrypt_sensitive_data( $tokens['refresh_token'] ) : '',
-			'expires_in' => $tokens['expires_in'],
-			'token_type' => $tokens['token_type'],
-			'created_at' => $tokens['created_at'],
-		];
+                if ( ! is_array( $tokens ) || empty( $tokens ) ) {
+                        return false;
+                }
 
-		return $decrypted_tokens;
-	}
+                $access_token = isset( $tokens['access_token'] ) ? Security::decrypt_sensitive_data( $tokens['access_token'] ) : '';
+                $refresh_token_encrypted = $tokens['refresh_token'] ?? '';
+                $refresh_token = '' !== $refresh_token_encrypted
+                        ? Security::decrypt_sensitive_data( $refresh_token_encrypted )
+                        : '';
+
+                return [
+                        'access_token' => $access_token,
+                        'refresh_token' => $refresh_token,
+                        'expires_in' => isset( $tokens['expires_in'] ) ? (int) $tokens['expires_in'] : 0,
+                        'token_type' => $tokens['token_type'] ?? 'Bearer',
+                        'created_at' => isset( $tokens['created_at'] ) ? (int) $tokens['created_at'] : 0,
+                ];
+        }
 
 	/**
 	 * Check if user is authenticated
@@ -328,9 +372,9 @@ class GoogleOAuth {
 		}
 
 		// Clear stored tokens
-		delete_option( self::TOKEN_OPTION );
-		return true;
-	}
+                SettingsManager::delete_option( self::TOKEN_OPTION );
+                return true;
+        }
 
 	/**
 	 * Get OAuth connection status for display

--- a/src/Setup/SettingsManager.php
+++ b/src/Setup/SettingsManager.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Centralized settings manager for option keys and menu state.
+ *
+ * @package FP_Digital_Marketing_Suite
+ */
+
+declare(strict_types=1);
+
+namespace FP\DigitalMarketing\Setup;
+
+/**
+ * Provides constants and helpers for managing plugin options.
+ */
+class SettingsManager {
+
+        /**
+         * Wizard progress option.
+         */
+        public const OPTION_WIZARD_PROGRESS = 'fp_digital_marketing_wizard_progress';
+
+        /**
+         * Wizard completed option.
+         */
+        public const OPTION_WIZARD_COMPLETED = 'fp_digital_marketing_wizard_completed';
+
+        /**
+         * Wizard menu state option.
+         */
+        public const OPTION_WIZARD_MENU_STATE = 'fp_digital_marketing_menu_state';
+
+        /**
+         * API keys option.
+         */
+        public const OPTION_API_KEYS = 'fp_digital_marketing_api_keys';
+
+        /**
+         * Sync settings option.
+         */
+        public const OPTION_SYNC_SETTINGS = 'fp_digital_marketing_sync_settings';
+
+        /**
+         * Report configuration option.
+         */
+        public const OPTION_REPORT_CONFIG = 'fp_digital_marketing_report_config';
+
+        /**
+         * User feedback option.
+         */
+        public const OPTION_USER_FEEDBACK = 'fp_digital_marketing_user_feedback';
+
+        /**
+         * OAuth state option.
+         */
+        public const OPTION_OAUTH_STATE = 'fp_digital_marketing_oauth_state';
+
+        /**
+         * Google OAuth tokens option.
+         */
+        public const OPTION_GOOGLE_OAUTH_TOKENS = 'fp_digital_marketing_google_oauth_tokens';
+
+        /**
+         * Google OAuth settings option.
+         */
+        public const OPTION_GOOGLE_OAUTH_SETTINGS = 'fp_digital_marketing_google_oauth_settings';
+
+        /**
+         * Key used to track wizard availability inside the menu state option.
+         */
+        private const MENU_STATE_WIZARD_ENABLED_KEY = 'wizard_enabled';
+
+        /**
+         * Key used to store registered menu slugs inside the menu state option.
+         */
+        private const MENU_STATE_REGISTERED_SLUGS_KEY = 'registered_slugs';
+
+        /**
+         * Legacy option fallbacks for backwards compatibility.
+         *
+         * @var array<string, array<int, string>>
+         */
+        private const OPTION_FALLBACKS = [
+                self::OPTION_OAUTH_STATE => [ 'fp_dms_oauth_state' ],
+                self::OPTION_GOOGLE_OAUTH_TOKENS => [ 'fp_dms_google_oauth_tokens' ],
+                self::OPTION_GOOGLE_OAUTH_SETTINGS => [ 'fp_dms_google_oauth_settings' ],
+        ];
+
+        /**
+         * Get an option value with fallback support.
+         *
+         * @param string $option  Option name.
+         * @param mixed  $default Default value.
+         * @return mixed
+         */
+        public static function get_option( string $option, $default = false ) {
+                $sentinel = new \stdClass();
+                $value = get_option( $option, $sentinel );
+
+                if ( $value !== $sentinel ) {
+                        return $value;
+                }
+
+                foreach ( self::OPTION_FALLBACKS[ $option ] ?? [] as $legacy_option ) {
+                        $legacy_value = get_option( $legacy_option, $sentinel );
+                        if ( $legacy_value !== $sentinel ) {
+                                return $legacy_value;
+                        }
+                }
+
+                return $default;
+        }
+
+        /**
+         * Update an option value.
+         *
+         * @param string $option   Option name.
+         * @param mixed  $value    Option value.
+         * @param bool   $autoload Whether to autoload the option.
+         * @return bool True on success.
+         */
+        public static function update_option( string $option, $value, bool $autoload = true ): bool {
+                return update_option( $option, $value, $autoload );
+        }
+
+        /**
+         * Delete an option value, removing any legacy fallbacks as well.
+         *
+         * @param string $option Option name.
+         * @return bool True if the option was deleted.
+         */
+        public static function delete_option( string $option ): bool {
+                $deleted = delete_option( $option );
+
+                foreach ( self::OPTION_FALLBACKS[ $option ] ?? [] as $legacy_option ) {
+                        delete_option( $legacy_option );
+                }
+
+                return $deleted;
+        }
+
+        /**
+         * Check if the wizard menu entry is enabled.
+         *
+         * @return bool
+         */
+        public static function is_wizard_menu_enabled(): bool {
+                $state = self::get_menu_state();
+
+                if ( array_key_exists( self::MENU_STATE_WIZARD_ENABLED_KEY, $state ) ) {
+                        return (bool) $state[ self::MENU_STATE_WIZARD_ENABLED_KEY ];
+                }
+
+                return true;
+        }
+
+        /**
+         * Enable the wizard menu entry and ensure the slug is tracked.
+         *
+         * @param string $slug Menu slug to register.
+         * @return void
+         */
+        public static function enable_wizard_menu( string $slug ): void {
+                $slug = self::sanitize_slug( $slug );
+                $state = self::get_menu_state();
+
+                $state[ self::MENU_STATE_WIZARD_ENABLED_KEY ] = true;
+                $state['wizard_status'] = 'pending';
+                $state['updated_at'] = time();
+
+                $registered = $state[ self::MENU_STATE_REGISTERED_SLUGS_KEY ] ?? [];
+                if ( ! in_array( $slug, $registered, true ) ) {
+                        $registered[] = $slug;
+                }
+
+                $state[ self::MENU_STATE_REGISTERED_SLUGS_KEY ] = self::sanitize_slug_list( $registered );
+
+                update_option( self::OPTION_WIZARD_MENU_STATE, $state, false );
+        }
+
+        /**
+         * Disable the wizard menu entry and remove its slug from the registry.
+         *
+         * @param string $slug   Menu slug to remove.
+         * @param string $status Final wizard status (completed, skipped, etc.).
+         * @return void
+         */
+        public static function disable_wizard_menu( string $slug, string $status = 'completed' ): void {
+                $slug = self::sanitize_slug( $slug );
+                $state = self::get_menu_state();
+
+                $state[ self::MENU_STATE_WIZARD_ENABLED_KEY ] = false;
+                $state['wizard_status'] = $status;
+                $state['wizard_completed_at'] = time();
+                $state['updated_at'] = time();
+
+                $registered = $state[ self::MENU_STATE_REGISTERED_SLUGS_KEY ] ?? [];
+                $registered = array_values( array_filter(
+                        $registered,
+                        static function ( string $existing ) use ( $slug ) {
+                                return $existing !== $slug;
+                        }
+                ) );
+
+                $state[ self::MENU_STATE_REGISTERED_SLUGS_KEY ] = self::sanitize_slug_list( $registered );
+
+                update_option( self::OPTION_WIZARD_MENU_STATE, $state, false );
+        }
+
+        /**
+         * Persist the list of registered menu slugs.
+         *
+         * @param array<int, string> $slugs Menu slugs to store.
+         * @return void
+         */
+        public static function set_registered_menu_slugs( array $slugs ): void {
+                $state = self::get_menu_state();
+                $state[ self::MENU_STATE_REGISTERED_SLUGS_KEY ] = self::sanitize_slug_list( $slugs );
+                $state['updated_at'] = time();
+
+                update_option( self::OPTION_WIZARD_MENU_STATE, $state, false );
+        }
+
+        /**
+         * Remove a slug from the registered menu list without altering other state.
+         *
+         * @param string $slug Menu slug to remove.
+         * @return void
+         */
+        public static function remove_registered_menu_slug( string $slug ): void {
+                $slug = self::sanitize_slug( $slug );
+                $state = self::get_menu_state();
+                $registered = $state[ self::MENU_STATE_REGISTERED_SLUGS_KEY ] ?? [];
+
+                if ( empty( $registered ) ) {
+                        return;
+                }
+
+                $filtered = array_values( array_filter(
+                        $registered,
+                        static function ( string $existing ) use ( $slug ) {
+                                return $existing !== $slug;
+                        }
+                ) );
+
+                if ( $filtered === $registered ) {
+                        return;
+                }
+
+                $state[ self::MENU_STATE_REGISTERED_SLUGS_KEY ] = self::sanitize_slug_list( $filtered );
+                $state['updated_at'] = time();
+
+                update_option( self::OPTION_WIZARD_MENU_STATE, $state, false );
+        }
+
+        /**
+         * Get the list of registered menu slugs.
+         *
+         * @return array<int, string>
+         */
+        public static function get_registered_menu_slugs(): array {
+                $state = self::get_menu_state();
+                $registered = $state[ self::MENU_STATE_REGISTERED_SLUGS_KEY ] ?? [];
+
+                return self::sanitize_slug_list( (array) $registered );
+        }
+
+        /**
+         * Retrieve the persisted menu state array.
+         *
+         * @return array<string, mixed>
+         */
+        private static function get_menu_state(): array {
+                $state = get_option( self::OPTION_WIZARD_MENU_STATE, [] );
+
+                if ( ! is_array( $state ) ) {
+                        return [];
+                }
+
+                return $state;
+        }
+
+        /**
+         * Sanitize a list of slugs ensuring uniqueness.
+         *
+         * @param array<int, string> $slugs Slugs to sanitize.
+         * @return array<int, string>
+         */
+        private static function sanitize_slug_list( array $slugs ): array {
+                $sanitized = array_map( [ self::class, 'sanitize_slug' ], $slugs );
+                $sanitized = array_filter( $sanitized, static function ( string $slug ): bool {
+                        return $slug !== '';
+                } );
+
+                return array_values( array_unique( $sanitized ) );
+        }
+
+        /**
+         * Sanitize a single slug value.
+         *
+         * @param string $slug Slug to sanitize.
+         * @return string
+         */
+        private static function sanitize_slug( string $slug ): string {
+                if ( function_exists( 'sanitize_key' ) ) {
+                        return sanitize_key( $slug );
+                }
+
+                return strtolower( preg_replace( '/[^a-z0-9_\-]/', '', $slug ) ?? '' );
+        }
+}

--- a/tests/OnboardingWizardTest.php
+++ b/tests/OnboardingWizardTest.php
@@ -7,6 +7,7 @@
 
 use PHPUnit\Framework\TestCase;
 use FP\DigitalMarketing\Admin\OnboardingWizard;
+use FP\DigitalMarketing\Setup\SettingsManager;
 
 /**
  * Test class for OnboardingWizard
@@ -29,7 +30,7 @@ class OnboardingWizardTest extends TestCase {
 		$this->assertFalse( OnboardingWizard::is_completed() );
 
 		// Simulate completion
-		update_option( 'fp_digital_marketing_wizard_completed', true );
+                update_option( SettingsManager::OPTION_WIZARD_COMPLETED, true );
 		$this->assertTrue( OnboardingWizard::is_completed() );
 
 		// Reset
@@ -49,9 +50,9 @@ class OnboardingWizardTest extends TestCase {
 			'services' => [ 'google_analytics_4' ],
 			'metrics' => [ 'sessions', 'pageviews' ],
 		];
-		update_option( 'fp_digital_marketing_wizard_progress', $progress );
+                update_option( SettingsManager::OPTION_WIZARD_PROGRESS, $progress );
 
-		$saved_progress = get_option( 'fp_digital_marketing_wizard_progress', [] );
+                $saved_progress = get_option( SettingsManager::OPTION_WIZARD_PROGRESS, [] );
 		$this->assertEquals( $progress['services'], $saved_progress['services'] );
 		$this->assertEquals( $progress['metrics'], $saved_progress['metrics'] );
 
@@ -64,15 +65,15 @@ class OnboardingWizardTest extends TestCase {
 	 */
 	public function test_wizard_reset(): void {
 		// Set some options
-		update_option( 'fp_digital_marketing_wizard_completed', true );
-		update_option( 'fp_digital_marketing_wizard_progress', [ 'test' => 'data' ] );
+                update_option( SettingsManager::OPTION_WIZARD_COMPLETED, true );
+                update_option( SettingsManager::OPTION_WIZARD_PROGRESS, [ 'test' => 'data' ] );
 
 		// Reset
 		OnboardingWizard::reset();
 
 		// Verify options are cleared
-		$this->assertFalse( get_option( 'fp_digital_marketing_wizard_completed', false ) );
-		$this->assertEquals( [], get_option( 'fp_digital_marketing_wizard_progress', [] ) );
+                $this->assertFalse( get_option( SettingsManager::OPTION_WIZARD_COMPLETED, false ) );
+                $this->assertEquals( [], get_option( SettingsManager::OPTION_WIZARD_PROGRESS, [] ) );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -136,6 +136,7 @@ function fp_dms_cleanup_options() {
         'fp_digital_marketing_demo_option',
         'fp_digital_marketing_report_config',
         'fp_digital_marketing_user_feedback',
+        'fp_digital_marketing_menu_state',
         'fp_digital_marketing_wizard_progress',
         'fp_digital_marketing_wizard_completed',
 
@@ -161,6 +162,9 @@ function fp_dms_cleanup_options() {
         'fp_dms_enable_performance_monitoring',
 
         // OAuth tokens and integration state.
+        'fp_digital_marketing_google_oauth_tokens',
+        'fp_digital_marketing_google_oauth_settings',
+        'fp_digital_marketing_oauth_state',
         'fp_dms_google_oauth_tokens',
         'fp_dms_google_oauth_settings',
         'fp_dms_oauth_state',


### PR DESCRIPTION
## Summary
- centralize onboarding wizard option management in a new Setup\SettingsManager and apply capability-aware access controls in the wizard handlers
- persist and update registered menu slugs through MenuManager so the setup wizard entry is hidden once onboarding completes
- harden Google OAuth token exchange and migrate related option keys, updating settings cleanup, tests, and uninstall routines accordingly

## Testing
- composer test *(fails: phpunit binary not available before installing dev dependencies)*
- vendor/bin/phpunit *(fails: suite expects a full WordPress environment and numerous pre-existing tests report errors in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68d39a39dcd8832faa9d60dcf61d87b1