### PR TITLE
Improve secret management and OAuth credential handling

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -16,6 +16,7 @@ use FP\DigitalMarketing\DataSources\GoogleSearchConsole;
 use FP\DigitalMarketing\DataSources\MicrosoftClarity;
 use FP\DigitalMarketing\Helpers\SyncEngine;
 use FP\DigitalMarketing\Helpers\Security;
+use FP\DigitalMarketing\Helpers\SecretsManager;
 use FP\DigitalMarketing\Helpers\PerformanceCache;
 use FP\DigitalMarketing\Helpers\XmlSitemap;
 use FP\DigitalMarketing\Helpers\SchemaGenerator;
@@ -81,15 +82,6 @@ class Settings {
 	 * API Keys option name
 	 */
 	private const OPTION_API_KEYS = 'fp_digital_marketing_api_keys';
-
-	/**
-	 * Sensitive API keys stored encrypted.
-	 */
-	private const SENSITIVE_API_KEYS = [
-		'google_client_secret',
-		'api_token',
-		'secret_key',
-	];
 
 	/**
 	 * Sync settings option name
@@ -617,29 +609,26 @@ class Settings {
 	 * @return void
 	 */
 	public function render_api_keys_field(): void {
-		$api_keys = get_option( self::OPTION_API_KEYS, [] );
+               $api_keys = SecretsManager::get_api_keys();
+               $display_context = SecretsManager::prepare_for_display( $api_keys );
+               $display_api_keys = $display_context['values'];
+               $decryption_errors = $display_context['errors'];
 
-		if ( ! is_array( $api_keys ) ) {
-		        $api_keys = [];
-		}
+               $oauth = new GoogleOAuth();
+               $connection_status = $oauth->get_connection_status();
+               ?>
+               <div class="ga4-configuration">
+                       <h4><?php esc_html_e( 'Google Analytics 4', 'fp-digital-marketing' ); ?></h4>
 
-		$display_api_keys = $api_keys;
+                       <?php if ( ! empty( $decryption_errors ) ) : ?>
+                               <div class="notice notice-warning inline">
+                                       <p>
+                                               <?php esc_html_e( 'Impossibile decifrare alcune chiavi sensibili. Inserisci nuovamente i valori e salvali.', 'fp-digital-marketing' ); ?>
+                                       </p>
+                               </div>
+                       <?php endif; ?>
 
-		foreach ( self::SENSITIVE_API_KEYS as $sensitive_key ) {
-		        if ( isset( $api_keys[ $sensitive_key ] ) && is_string( $api_keys[ $sensitive_key ] ) && '' !== $api_keys[ $sensitive_key ] ) {
-		                $display_api_keys[ $sensitive_key ] = Security::decrypt_sensitive_data( $api_keys[ $sensitive_key ] );
-		        } else {
-		                $display_api_keys[ $sensitive_key ] = '';
-		        }
-		}
-
-		$oauth = new GoogleOAuth();
-		$connection_status = $oauth->get_connection_status();
-		?>
-		<div class="ga4-configuration">
-			<h4><?php esc_html_e( 'Google Analytics 4', 'fp-digital-marketing' ); ?></h4>
-			
-			<table class="form-table">
+                       <table class="form-table">
 				<tr>
 					<th scope="row"><?php esc_html_e( 'Client ID', 'fp-digital-marketing' ); ?></th>
 					<td>
@@ -896,38 +885,49 @@ class Settings {
 			wp_die( esc_html__( 'Non autorizzato', 'fp-digital-marketing' ) );
 		}
 
-		$current_keys = get_option( self::OPTION_API_KEYS, [] );
-		$sanitized = [];
+               $current_keys = SecretsManager::get_api_keys();
+               $sanitized = [];
 
-		foreach ( $input as $key => $value ) {
-		        $sanitized_key = sanitize_key( $key );
-		        $sanitized_value = sanitize_text_field( $value );
+               foreach ( $input as $key => $value ) {
+                       $sanitized_key = sanitize_key( $key );
 
-		        // Encrypt sensitive API keys
-		        if ( in_array( $sanitized_key, self::SENSITIVE_API_KEYS, true ) && ! empty( $sanitized_value ) ) {
-				// Only encrypt if value has changed to avoid double encryption
-				if ( ! isset( $current_keys[ $sanitized_key ] ) || 
-					 Security::decrypt_sensitive_data( $current_keys[ $sanitized_key ] ) !== $sanitized_value ) {
-					$sanitized[ $sanitized_key ] = Security::encrypt_sensitive_data( $sanitized_value );
-					
-					// Log API key change
-					error_log( sprintf( 
-						'FP Digital Marketing: API key %s updated by user %d', 
-						$sanitized_key, 
-						get_current_user_id() 
-					) );
-				} else {
-					// Keep existing encrypted value
-					$sanitized[ $sanitized_key ] = $current_keys[ $sanitized_key ];
-				}
-			} else {
-				// Non-sensitive keys stored as-is (already sanitized)
-				$sanitized[ $sanitized_key ] = $sanitized_value;
-			}
-		}
+                       if ( '' === $sanitized_key ) {
+                               continue;
+                       }
 
-		return $sanitized;
-	}
+                       if ( is_array( $value ) ) {
+                               continue;
+                       }
+
+                       $scalar_value = is_scalar( $value ) ? (string) $value : '';
+                       $sanitized_value = sanitize_text_field( wp_unslash( $scalar_value ) );
+
+                       $sanitized[ $sanitized_key ] = $sanitized_value;
+               }
+
+               $prepared = SecretsManager::prepare_for_storage( $sanitized, $current_keys );
+
+               foreach ( $prepared['updated_sensitive_keys'] as $updated_key ) {
+                       if ( isset( $sanitized[ $updated_key ] ) && '' !== $sanitized[ $updated_key ] ) {
+                               error_log( sprintf(
+                                       'FP Digital Marketing: API key %s updated by user %d',
+                                       $updated_key,
+                                       get_current_user_id()
+                               ) );
+                       }
+               }
+
+               if ( ! empty( $prepared['errors'] ) ) {
+                       foreach ( $prepared['errors'] as $error_key ) {
+                               error_log( sprintf(
+                                       'FP Digital Marketing: unable to decrypt stored secret for %s during save. Re-encrypting with the provided value.',
+                                       $error_key
+                               ) );
+                       }
+               }
+
+               return $prepared['values'];
+        }
 
 	/**
 	 * Get demo option value
@@ -944,29 +944,9 @@ class Settings {
 	 * @param bool $decrypt_sensitive Whether to decrypt sensitive keys for display.
 	 * @return array The API keys array with sensitive values decrypted if requested.
 	 */
-	public function get_api_keys( bool $decrypt_sensitive = true ): array {
-		$api_keys = get_option( self::OPTION_API_KEYS, [] );
-
-		if ( ! is_array( $api_keys ) ) {
-		        $api_keys = [];
-		}
-
-		if ( ! $decrypt_sensitive ) {
-		        return $api_keys;
-		}
-
-		$decrypted_keys = [];
-
-		foreach ( $api_keys as $key => $value ) {
-		        if ( in_array( $key, self::SENSITIVE_API_KEYS, true ) && ! empty( $value ) ) {
-		                $decrypted_keys[ $key ] = Security::decrypt_sensitive_data( $value );
-		        } else {
-		                $decrypted_keys[ $key ] = $value;
-			}
-		}
-
-		return $decrypted_keys;
-	}
+        public function get_api_keys( bool $decrypt_sensitive = true ): array {
+                return SecretsManager::get_api_keys( $decrypt_sensitive );
+        }
 
 	/**
 	 * Handle cache actions triggered via GET requests.

--- a/src/DataSources/GoogleOAuth.php
+++ b/src/DataSources/GoogleOAuth.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace FP\DigitalMarketing\DataSources;
 
 use FP\DigitalMarketing\Helpers\Security;
+use FP\DigitalMarketing\Helpers\SecretsManager;
 use FP\DigitalMarketing\Setup\SettingsManager;
 
 /**
@@ -80,22 +81,70 @@ class GoogleOAuth {
 	 * @return array OAuth credentials
 	 */
         private function get_oauth_credentials(): array {
-                $api_keys = SettingsManager::get_option( SettingsManager::OPTION_API_KEYS, [] );
+                $api_keys = SecretsManager::get_api_keys();
+                $display_context = SecretsManager::prepare_for_display( $api_keys );
+                $decrypted_keys = $display_context['values'];
+                $decryption_errors = $display_context['errors'];
 
-                $client_id = $api_keys['google_client_id'] ?? '';
-                $raw_client_secret = $api_keys['google_client_secret'] ?? '';
+                $client_id = '';
+                if ( isset( $decrypted_keys['google_client_id'] ) && is_string( $decrypted_keys['google_client_id'] ) ) {
+                        $client_id = trim( $decrypted_keys['google_client_id'] );
+                }
+
                 $client_secret = '';
+                if ( isset( $decrypted_keys['google_client_secret'] ) && is_string( $decrypted_keys['google_client_secret'] ) ) {
+                        $client_secret = $decrypted_keys['google_client_secret'];
+                }
 
-                if ( $raw_client_secret !== '' && $raw_client_secret !== null ) {
-                        $decrypted_secret = Security::decrypt_sensitive_data( $raw_client_secret );
+                $secret_decryption_failed = in_array( 'google_client_secret', $decryption_errors, true );
+                $credentials_expired = $secret_decryption_failed || '' === $client_id || '' === $client_secret;
 
-                        $client_secret = ($decrypted_secret !== '' && $decrypted_secret !== null) ? $decrypted_secret : $raw_client_secret;
+                $status = SettingsManager::get_option( self::OAUTH_SETTINGS_OPTION, [] );
+                if ( ! is_array( $status ) ) {
+                        $status = [];
+                }
+
+                $reason = 'ok';
+                if ( $secret_decryption_failed ) {
+                        $reason = 'decryption_failed';
+                } elseif ( '' === $client_id || '' === $client_secret ) {
+                        $reason = 'missing_credentials';
+                }
+
+                $status_update = array_merge(
+                        $status,
+                        [
+                                'credentials_expired' => $credentials_expired,
+                                'decryption_failed' => $secret_decryption_failed,
+                                'has_client_id' => '' !== $client_id,
+                                'has_client_secret' => '' !== $client_secret,
+                                'reason' => $reason,
+                        ]
+                );
+
+                $status_has_changed = (
+                        ( $status['credentials_expired'] ?? null ) !== $status_update['credentials_expired'] ||
+                        ( $status['decryption_failed'] ?? null ) !== $status_update['decryption_failed'] ||
+                        ( $status['has_client_id'] ?? null ) !== $status_update['has_client_id'] ||
+                        ( $status['has_client_secret'] ?? null ) !== $status_update['has_client_secret'] ||
+                        ( $status['reason'] ?? null ) !== $status_update['reason']
+                );
+
+                if ( $status_has_changed ) {
+                        $status_update['checked_at'] = time();
+
+                        if ( ! $credentials_expired ) {
+                                $status_update['last_valid_credentials_at'] = time();
+                        }
+
+                        SettingsManager::update_option( self::OAUTH_SETTINGS_OPTION, $status_update, false );
                 }
 
                 return [
                         'client_id' => $client_id,
                         'client_secret' => $client_secret,
                         'redirect_uri' => admin_url( 'admin.php?page=fp-digital-marketing-settings&ga4_callback=1' ),
+                        'expired' => $credentials_expired,
                 ];
         }
 

--- a/src/Helpers/SecretsManager.php
+++ b/src/Helpers/SecretsManager.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Secrets Manager Helper
+ *
+ * Centralizes handling of sensitive settings such as API keys. This helper
+ * ensures sensitive values are decrypted when displayed in the admin UI and
+ * re-encrypted safely when persisted back to WordPress options.
+ *
+ * @package FP_Digital_Marketing_Suite
+ */
+
+declare(strict_types=1);
+
+namespace FP\DigitalMarketing\Helpers;
+
+use FP\DigitalMarketing\Setup\SettingsManager;
+
+/**
+ * Secrets manager utility class.
+ */
+class SecretsManager {
+
+		/**
+		 * Keys that should be treated as sensitive and stored encrypted.
+		 */
+	public const SENSITIVE_KEYS = [
+		'google_client_secret',
+		'api_token',
+		'secret_key',
+	];
+
+		/**
+		 * Retrieve stored API keys.
+		 *
+		 * @param bool $decrypt_sensitive Whether to decrypt sensitive values.
+		 * @return array<string, mixed>
+		 */
+	public static function get_api_keys( bool $decrypt_sensitive = false ): array {
+			$api_keys = SettingsManager::get_option( SettingsManager::OPTION_API_KEYS, [] );
+
+		if ( ! is_array( $api_keys ) ) {
+				return [];
+		}
+
+		if ( ! $decrypt_sensitive ) {
+				return $api_keys;
+		}
+
+			$prepared = self::prepare_for_display( $api_keys );
+
+			return $prepared['values'];
+	}
+
+		/**
+		 * Decrypt sensitive values for safe rendering in admin forms.
+		 *
+		 * @param array<string, mixed>    $values         Raw option values.
+		 * @param array<int, string>|null $sensitive_keys Optional override for sensitive keys.
+		 * @return array{values: array<string, mixed>, errors: array<int, string>} Decrypted values and keys that failed to decrypt.
+		 */
+	public static function prepare_for_display( array $values, ?array $sensitive_keys = null ): array {
+			$sensitive_keys = $sensitive_keys ?? self::SENSITIVE_KEYS;
+			$errors         = [];
+
+		foreach ( $sensitive_keys as $key ) {
+			if ( ! array_key_exists( $key, $values ) ) {
+				continue;
+			}
+
+				$raw_value = $values[ $key ];
+
+			if ( ! is_string( $raw_value ) || '' === $raw_value ) {
+					$values[ $key ] = '';
+					continue;
+			}
+
+				$result = self::decrypt_value( $raw_value );
+
+			if ( $result['decryption_failed'] ) {
+					$errors[] = $key;
+			}
+
+				$values[ $key ] = $result['value'];
+		}
+
+			return [
+				'values' => $values,
+				'errors' => $errors,
+			];
+	}
+
+		/**
+		 * Prepare sanitized values for secure storage.
+		 *
+		 * @param array<string, string>   $values   Sanitized user input.
+		 * @param array<string, mixed>    $existing Previously stored values.
+		 * @param array<int, string>|null $sensitive_keys Optional override for sensitive keys.
+		 * @return array{values: array<string, mixed>, updated_sensitive_keys: array<int, string>, errors: array<int, string>} Prepared values and metadata.
+		 */
+	public static function prepare_for_storage( array $values, array $existing, ?array $sensitive_keys = null ): array {
+			$sensitive_keys = $sensitive_keys ?? self::SENSITIVE_KEYS;
+
+			$prepared = [
+				'values'                 => [],
+				'updated_sensitive_keys' => [],
+				'errors'                 => [],
+			];
+
+			foreach ( $values as $key => $value ) {
+				if ( in_array( $key, $sensitive_keys, true ) ) {
+						$sensitive_result           = self::prepare_sensitive_value_for_storage( $key, $value, $existing );
+						$prepared['values'][ $key ] = $sensitive_result['value'];
+
+					if ( $sensitive_result['was_updated'] ) {
+						$prepared['updated_sensitive_keys'][] = $key;
+					}
+
+					if ( $sensitive_result['error'] ) {
+							$prepared['errors'][] = $key;
+					}
+				} else {
+						$prepared['values'][ $key ] = is_string( $value ) ? $value : (string) $value;
+				}
+			}
+
+			return $prepared;
+	}
+
+		/**
+		 * Decrypt a single stored sensitive value.
+		 *
+		 * @param string|null $value Stored value.
+		 * @return array{value: string, had_value: bool, decryption_failed: bool}
+		 */
+	public static function decrypt_value( ?string $value ): array {
+			$value = is_string( $value ) ? $value : '';
+
+		if ( '' === $value ) {
+				return [
+					'value'             => '',
+					'had_value'         => false,
+					'decryption_failed' => false,
+				];
+		}
+
+			$decrypted = Security::decrypt_sensitive_data( $value );
+
+		if ( '' === $decrypted ) {
+				return [
+					'value'             => '',
+					'had_value'         => true,
+					'decryption_failed' => true,
+				];
+		}
+
+			return [
+				'value'             => $decrypted,
+				'had_value'         => true,
+				'decryption_failed' => false,
+			];
+	}
+
+		/**
+		 * Determine if a key is considered sensitive.
+		 *
+		 * @param string $key Option key name.
+		 * @return bool True when the key must be encrypted.
+		 */
+	public static function is_sensitive_key( string $key ): bool {
+			return in_array( $key, self::SENSITIVE_KEYS, true );
+	}
+
+		/**
+		 * Prepare a single sensitive value for storage.
+		 *
+		 * @param string               $key      Option key name.
+		 * @param string|mixed         $value    Sanitized user input.
+		 * @param array<string, mixed> $existing Existing stored values.
+		 * @return array{value: string, was_updated: bool, error: bool}
+		 */
+	private static function prepare_sensitive_value_for_storage( string $key, $value, array $existing ): array {
+			$normalized_value = is_string( $value ) ? trim( $value ) : '';
+
+			$existing_encrypted = '';
+		if ( isset( $existing[ $key ] ) && is_string( $existing[ $key ] ) ) {
+				$existing_encrypted = $existing[ $key ];
+		}
+
+			$existing_plain = '';
+			$existing_error = false;
+
+		if ( '' !== $existing_encrypted ) {
+				$existing_plain = Security::decrypt_sensitive_data( $existing_encrypted );
+
+			if ( '' === $existing_plain ) {
+					$existing_error = true;
+			}
+		}
+
+		if ( '' === $normalized_value ) {
+				return [
+					'value'       => '',
+					'was_updated' => '' !== $existing_plain,
+					'error'       => $existing_error,
+				];
+		}
+
+		if ( '' !== $existing_plain && hash_equals( $existing_plain, $normalized_value ) ) {
+				return [
+					'value'       => $existing_encrypted,
+					'was_updated' => false,
+					'error'       => $existing_error,
+				];
+		}
+
+			return [
+				'value'       => Security::encrypt_sensitive_data( $normalized_value ),
+				'was_updated' => true,
+				'error'       => $existing_error,
+			];
+	}
+}


### PR DESCRIPTION
## Summary
- add a SecretsManager helper to centralize decrypt/encrypt logic for sensitive options
- update the admin settings form to rely on the helper for displaying and saving decrypted API secrets with improved logging
- enhance Google OAuth credential loading to surface decryption failures, expiration status, and safe defaults

## Testing
- php -l src/Admin/Settings.php
- php -l src/DataSources/GoogleOAuth.php
- php -l src/Helpers/SecretsManager.php
- vendor/bin/phpcs src/Helpers/SecretsManager.php
- composer phpcs *(fails: existing coding standard violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a30b6c3c832f850ba118b0ee7802