### PR TITLE
Implement cache invalidation helpers and CSV sanitization

### DIFF
--- a/src/Admin/AlertingAdmin.php
+++ b/src/Admin/AlertingAdmin.php
@@ -635,13 +635,13 @@ class AlertingAdmin {
 			return;
 		}
 
-		wp_enqueue_script(
-			'fp-dms-alerts',
-			FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/alerts-admin.js',
-			[ 'jquery' ],
-			FP_DIGITAL_MARKETING_VERSION,
-			true
-		);
+                wp_enqueue_script(
+                        'fp-dms-alerts',
+                        FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/alerts-admin.js',
+                        [ 'jquery', 'wp-util' ],
+                        FP_DIGITAL_MARKETING_VERSION,
+                        true
+                );
 
 		wp_localize_script( 'fp-dms-alerts', 'fpDmsAlerts', [
 			'ajaxUrl' => admin_url( 'admin-ajax.php' ),

--- a/src/Admin/AnomalyDetectionAdmin.php
+++ b/src/Admin/AnomalyDetectionAdmin.php
@@ -962,13 +962,13 @@ class AnomalyDetectionAdmin {
 			return;
 		}
 
-		wp_enqueue_script(
-			'fp-dms-anomaly-admin',
-			FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/anomaly-admin.js',
-			[ 'jquery' ],
-			FP_DIGITAL_MARKETING_VERSION,
-			true
-		);
+                wp_enqueue_script(
+                        'fp-dms-anomaly-admin',
+                        FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/anomaly-admin.js',
+                        [ 'jquery', 'wp-util' ],
+                        FP_DIGITAL_MARKETING_VERSION,
+                        true
+                );
 
 		wp_localize_script( 'fp-dms-anomaly-admin', 'fp_dms_anomaly_admin', [
 			'ajax_url' => admin_url( 'admin-ajax.php' ),

--- a/src/Admin/ConversionEventsAdmin.php
+++ b/src/Admin/ConversionEventsAdmin.php
@@ -15,6 +15,7 @@ use FP\DigitalMarketing\Models\ConversionEvent;
 use FP\DigitalMarketing\Database\ConversionEventsTable;
 use FP\DigitalMarketing\Helpers\Capabilities;
 use FP\DigitalMarketing\Admin\MenuManager;
+use FP\DigitalMarketing\Tools\Exports\CsvExporter;
 
 /**
  * Conversion Events Admin class
@@ -864,76 +865,63 @@ class ConversionEventsAdmin {
 	 * @return string CSV content
 	 */
 	private function generate_csv_content( array $events ): string {
-		$csv_lines = [];
-		
-		// CSV headers
-                $headers = [
-                        __( 'ID', 'fp-digital-marketing' ),
-                        __( 'ID Evento', 'fp-digital-marketing' ),
-                        __( 'Nome Evento', 'fp-digital-marketing' ),
-                        __( 'Tipo', 'fp-digital-marketing' ),
-                        __( 'Cliente ID', 'fp-digital-marketing' ),
-                        __( 'Sorgente', 'fp-digital-marketing' ),
-                        __( 'ID Evento Sorgente', 'fp-digital-marketing' ),
-                        __( 'Valore Evento', 'fp-digital-marketing' ),
-                        __( 'Valuta', 'fp-digital-marketing' ),
-                        __( 'Duplicato', 'fp-digital-marketing' ),
-                        __( 'Data Creazione', 'fp-digital-marketing' ),
-                        __( 'Data Elaborazione', 'fp-digital-marketing' ),
-                ];
+		$handle = fopen( 'php://temp', 'r+' );
 
-                $csv_lines[] = $this->array_to_csv_line( $headers );
+		if ( false === $handle ) {
+			return '';
+		}
 
-                // Add event data
-                foreach ( $events as $event ) {
-                        $is_duplicate = '';
+		fwrite( $handle, "\xEF\xBB\xBF" );
 
-                        if ( isset( $event['is_duplicate'] ) ) {
-                                $is_duplicate = ( (int) $event['is_duplicate'] ) === 1
-                                        ? __( 'Sì', 'fp-digital-marketing' )
-                                        : __( 'No', 'fp-digital-marketing' );
-                        }
+		$headers = [
+			__( 'ID', 'fp-digital-marketing' ),
+			__( 'ID Evento', 'fp-digital-marketing' ),
+			__( 'Nome Evento', 'fp-digital-marketing' ),
+			__( 'Tipo', 'fp-digital-marketing' ),
+			__( 'Cliente ID', 'fp-digital-marketing' ),
+			__( 'Sorgente', 'fp-digital-marketing' ),
+			__( 'ID Evento Sorgente', 'fp-digital-marketing' ),
+			__( 'Valore Evento', 'fp-digital-marketing' ),
+			__( 'Valuta', 'fp-digital-marketing' ),
+			__( 'Duplicato', 'fp-digital-marketing' ),
+			__( 'Data Creazione', 'fp-digital-marketing' ),
+			__( 'Data Elaborazione', 'fp-digital-marketing' ),
+		];
 
-                        $row = [
-                                $event['id'] ?? '',
-                                $event['event_id'] ?? '',
-                                $event['event_name'] ?? '',
-                                $event['event_type'] ?? '',
-                                $event['client_id'] ?? '',
-                                $event['source'] ?? '',
-                                $event['source_event_id'] ?? '',
-                                $event['event_value'] ?? '',
-                                $event['currency'] ?? '',
-                                $is_duplicate,
-                                $event['created_at'] ?? '',
-                                $event['processed_at'] ?? '',
-                        ];
+		CsvExporter::write_row( $handle, $headers );
 
-                        $csv_lines[] = $this->array_to_csv_line( $row );
-                }
-		
-		return implode( "\n", $csv_lines );
-	}
-	
-	/**
-	 * Convert array to CSV line
-	 *
-	 * @param array $data Data array
-	 * @return string CSV line
-	 */
-	private function array_to_csv_line( array $data ): string {
-                $escaped_data = array_map( function( $field ) {
-                        // Escape quotes and wrap in quotes if necessary
-                        $field = (string) $field;
-                        $quote = '"';
-                        $field = str_replace( $quote, $quote . $quote, $field );
-                        if ( strpos( $field, ',' ) !== false || strpos( $field, $quote ) !== false || strpos( $field, "\n" ) !== false ) {
-                                $field = $quote . $field . $quote;
-                        }
-                        return $field;
-                }, $data );
-		
-		return implode( ',', $escaped_data );
+		foreach ( $events as $event ) {
+			$is_duplicate = '';
+
+			if ( isset( $event['is_duplicate'] ) ) {
+				$is_duplicate = ( (int) $event['is_duplicate'] ) === 1
+					? __( 'Sì', 'fp-digital-marketing' )
+					: __( 'No', 'fp-digital-marketing' );
+			}
+
+			$row = [
+				$event['id'] ?? '',
+				$event['event_id'] ?? '',
+				$event['event_name'] ?? '',
+				$event['event_type'] ?? '',
+				$event['client_id'] ?? '',
+				$event['source'] ?? '',
+				$event['source_event_id'] ?? '',
+				$event['event_value'] ?? '',
+				$event['currency'] ?? '',
+				$is_duplicate,
+				$event['created_at'] ?? '',
+				$event['processed_at'] ?? '',
+			];
+
+			CsvExporter::write_row( $handle, $row );
+		}
+
+		rewind( $handle );
+		$content = stream_get_contents( $handle );
+		fclose( $handle );
+
+		return is_string( $content ) ? $content : '';
 	}
 	
 	/**

--- a/src/Admin/Reports.php
+++ b/src/Admin/Reports.php
@@ -19,6 +19,7 @@ use FP\DigitalMarketing\Helpers\MetricsSchema;
 use FP\DigitalMarketing\Helpers\SyncEngine;
 use FP\DigitalMarketing\Helpers\Security;
 use FP\DigitalMarketing\Helpers\Capabilities;
+use FP\DigitalMarketing\Helpers\PerformanceCache;
 use FP\DigitalMarketing\Models\CustomReport;
 use FP\DigitalMarketing\Models\SocialSentiment;
 use FP\DigitalMarketing\Database\CustomReportsTable;
@@ -293,12 +294,17 @@ class Reports {
 			'status' => 'active',
 		]);
 
-		if ( $custom_report->save() ) {
-			add_action( 'admin_notices', function() {
-				echo '<div class="notice notice-success is-dismissible"><p>';
-				echo esc_html__( 'Report personalizzato creato con successo!', 'fp-digital-marketing' );
-				echo '</p></div>';
-			} );
+                if ( $custom_report->save() ) {
+                        PerformanceCache::clear_cache_by_pattern(
+                                sprintf( 'report_client_%d_*', $client_id ),
+                                PerformanceCache::CACHE_GROUP_REPORTS
+                        );
+
+                        add_action( 'admin_notices', function() {
+                                echo '<div class="notice notice-success is-dismissible"><p>';
+                                echo esc_html__( 'Report personalizzato creato con successo!', 'fp-digital-marketing' );
+                                echo '</p></div>';
+                        } );
 		} else {
 			add_action( 'admin_notices', function() {
 				echo '<div class="notice notice-error is-dismissible"><p>';

--- a/src/Helpers/CacheBenchmark.php
+++ b/src/Helpers/CacheBenchmark.php
@@ -12,6 +12,7 @@ namespace FP\DigitalMarketing\Helpers;
 use FP\DigitalMarketing\Models\MetricsCache;
 use FP\DigitalMarketing\Helpers\MetricsAggregator;
 use FP\DigitalMarketing\Helpers\PerformanceCache;
+use FP\DigitalMarketing\Performance\BenchmarkMath;
 use Exception;
 
 /**
@@ -110,15 +111,13 @@ class CacheBenchmark {
 		PerformanceCache::update_cache_settings( [ 'enabled' => $cache_enabled ] );
 
 		// Calculate metrics
-		$without_cache_count = count( $results['without_cache'] );
-		$with_cache_count = count( $results['with_cache'] );
-		$avg_without_cache = $without_cache_count > 0 ? array_sum( $results['without_cache'] ) / $without_cache_count : 0;
-		$avg_with_cache = $with_cache_count > 0 ? array_sum( $results['with_cache'] ) / $with_cache_count : 0;
+		$avg_without_cache = BenchmarkMath::average( $results['without_cache'] );
+		$avg_with_cache = BenchmarkMath::average( $results['with_cache'] );
 
 		$results['avg_without_cache'] = $avg_without_cache;
 		$results['avg_with_cache'] = $avg_with_cache;
-		$results['performance_improvement'] = $avg_without_cache > 0 ? ( ( $avg_without_cache - $avg_with_cache ) / $avg_without_cache ) * 100 : 0.0;
-		$results['cache_hit_ratio'] = $iterations > 1 ? (float) ( ( $cache_hits / ( $iterations - 1 ) ) * 100 ) : 0.0;
+		$results['performance_improvement'] = BenchmarkMath::safe_percentage( $avg_without_cache - $avg_with_cache, $avg_without_cache );
+		$results['cache_hit_ratio'] = BenchmarkMath::safe_percentage( $cache_hits, max( $iterations - 1, 0 ) );
 
 		// Store results
 		self::store_benchmark_results( $results );
@@ -208,9 +207,7 @@ class CacheBenchmark {
 		$results['final_peak'] = memory_get_peak_usage( true );
 
 		// Calculate efficiency (lower is better)
-		if ( $results['test_data_size'] > 0 ) {
-			$results['memory_efficiency'] = (float) ( $results['cache_memory_usage'] / $results['test_data_size'] );
-		}
+		$results['memory_efficiency'] = BenchmarkMath::safe_divide( $results['cache_memory_usage'], $results['test_data_size'] );
 
 		// Clean up
 		for ( $i = 0; $i < 100; $i++ ) {
@@ -398,18 +395,13 @@ class CacheBenchmark {
 		$results['total_requests'] = count( $results['request_times'] );
 
 		if ( 0 === $results['total_requests'] ) {
-			$results['avg_response_time'] = 0.0;
-			$results['min_response_time'] = 0.0;
-			$results['max_response_time'] = 0.0;
-			$results['error_rate'] = 0.0;
-
 			return $results;
 		}
 
-		$results['avg_response_time'] = array_sum( $results['request_times'] ) / $results['total_requests'];
-		$results['min_response_time'] = min( $results['request_times'] );
-		$results['max_response_time'] = max( $results['request_times'] );
-		$results['error_rate'] = ( $results['errors'] / $results['total_requests'] ) * 100;
+		$results['avg_response_time'] = BenchmarkMath::average( $results['request_times'] );
+		$results['min_response_time'] = BenchmarkMath::min( $results['request_times'] );
+		$results['max_response_time'] = BenchmarkMath::max( $results['request_times'] );
+		$results['error_rate'] = BenchmarkMath::safe_percentage( $results['errors'], $results['total_requests'] );
 
 		return $results;
 	}
@@ -470,19 +462,14 @@ class CacheBenchmark {
 			return $default_stats;
 		}
 
-		$cache_lookups = $total_cache_hits + $total_cache_misses;
-		$cache_hit_ratio = 0.0;
-
-		if ( $cache_lookups > 0 ) {
-			$cache_hit_ratio = ( $total_cache_hits / $cache_lookups ) * 100;
-		}
+		$cache_hit_ratio = BenchmarkMath::safe_percentage( $total_cache_hits, $total_cache_hits + $total_cache_misses );
 
 		return [
 			'total_requests' => $total_requests,
-			'avg_response_time' => array_sum( $all_times ) / count( $all_times ),
-			'min_response_time' => min( $all_times ),
-			'max_response_time' => max( $all_times ),
-			'error_rate' => ( $total_errors / $total_requests ) * 100,
+			'avg_response_time' => BenchmarkMath::average( $all_times ),
+			'min_response_time' => BenchmarkMath::min( $all_times ),
+			'max_response_time' => BenchmarkMath::max( $all_times ),
+			'error_rate' => BenchmarkMath::safe_percentage( $total_errors, $total_requests ),
 			'cache_hit_ratio' => $cache_hit_ratio,
 		];
 	}

--- a/src/Helpers/ConversionEventManager.php
+++ b/src/Helpers/ConversionEventManager.php
@@ -429,26 +429,16 @@ class ConversionEventManager {
 	 * @return void
 	 */
         private static function clear_related_caches( int $client_id, string $event_type ): void {
-                $base_key = PerformanceCache::generate_metrics_key([
-                        'client_id' => $client_id,
-                ]);
-
-                $prefix_end = strrpos( $base_key, '_' );
-                $prefix = false === $prefix_end ? $base_key : substr( $base_key, 0, $prefix_end );
+                $client_component = $client_id > 0 ? (string) $client_id : 'global';
 
                 $patterns_by_group = [
-                        PerformanceCache::CACHE_GROUP_AGGREGATED => $prefix . '_*',
-                        PerformanceCache::CACHE_GROUP_REPORTS => 'report_*',
+                        PerformanceCache::CACHE_GROUP_METRICS => sprintf( 'metrics_client_%s_*', $client_component ),
+                        PerformanceCache::CACHE_GROUP_AGGREGATED => sprintf( 'metrics_client_%s_*', $client_component ),
+                        PerformanceCache::CACHE_GROUP_REPORTS => sprintf( 'report_client_%s_*', $client_component ),
                 ];
 
                 foreach ( $patterns_by_group as $cache_group => $pattern ) {
-                        $prefixed_pattern = sprintf(
-                                'fp_dms_%s_%s',
-                                $cache_group,
-                                $pattern
-                        );
-
-                        PerformanceCache::clear_cache_by_pattern( $prefixed_pattern, $cache_group );
+                        PerformanceCache::clear_cache_by_pattern( $pattern, $cache_group );
                 }
         }
 

--- a/src/Helpers/DataExporter.php
+++ b/src/Helpers/DataExporter.php
@@ -12,6 +12,7 @@ namespace FP\DigitalMarketing\Helpers;
 use FP\DigitalMarketing\Helpers\Security;
 use FP\DigitalMarketing\Helpers\Capabilities;
 use FP\DigitalMarketing\Helpers\MetricsAggregator;
+use FP\DigitalMarketing\Tools\Exports\CsvExporter;
 
 /**
  * Data Export utility class for exporting reports and data
@@ -462,23 +463,33 @@ class DataExporter {
 		}
 
 		$output = fopen( 'php://temp', 'r+' );
-		
-		// Add BOM for UTF-8
-		fwrite( $output, "\xEF\xBB\xBF" );
-		
-		// Add header
-		fputcsv( $output, array_keys( $data[0] ) );
-		
-		// Add data rows
-		foreach ( $data as $row ) {
-			fputcsv( $output, $row );
+
+		if ( false === $output ) {
+			return '';
 		}
-		
+
+		fwrite( $output, "\xEF\xBB\xBF" );
+
+		$first_row = (array) $data[0];
+		$headers = array_keys( $first_row );
+		CsvExporter::write_row( $output, $headers );
+
+		foreach ( $data as $row ) {
+			$row_array = (array) $row;
+			$ordered_values = [];
+
+			foreach ( $headers as $header ) {
+				$ordered_values[] = $row_array[ $header ] ?? '';
+			}
+
+			CsvExporter::write_row( $output, $ordered_values );
+		}
+
 		rewind( $output );
 		$content = stream_get_contents( $output );
 		fclose( $output );
-		
-		return $content;
+
+		return is_string( $content ) ? $content : '';
 	}
 
 	/**

--- a/src/Helpers/EmailNotifications.php
+++ b/src/Helpers/EmailNotifications.php
@@ -540,12 +540,17 @@ class EmailNotifications {
 	 * @return bool Whether email can be sent
 	 */
 	private static function check_rate_limit( string $recipient, string $type ): bool {
-		$cache_key = "email_rate_limit_{$recipient}_{$type}";
-		$count = PerformanceCache::get( $cache_key, 'email_limits' ) ?: 0;
-		
-		// Allow max 10 emails per hour per type per recipient
-		return $count < 10;
-	}
+                $cache_key = "email_rate_limit_{$recipient}_{$type}";
+                $count = PerformanceCache::get( $cache_key, 'email_limits' ) ?: 0;
+
+                if ( $count >= 10 ) {
+                        self::increment_rate_stat( 'blocked' );
+                        return false;
+                }
+
+                // Allow max 10 emails per hour per type per recipient
+                return true;
+        }
 
 	/**
 	 * Update rate limit counter
@@ -554,11 +559,51 @@ class EmailNotifications {
 	 * @param string $type Email type
 	 * @return void
 	 */
-	private static function update_rate_limit( string $recipient, string $type ): void {
-		$cache_key = "email_rate_limit_{$recipient}_{$type}";
-		$count = PerformanceCache::get( $cache_key, 'email_limits' ) ?: 0;
+        private static function update_rate_limit( string $recipient, string $type ): void {
+                $cache_key = "email_rate_limit_{$recipient}_{$type}";
+                $count = PerformanceCache::get( $cache_key, 'email_limits' ) ?: 0;
                 PerformanceCache::set( $cache_key, 'email_limits', $count + 1, HOUR_IN_SECONDS );
-	}
+                self::increment_rate_stat( 'sent' );
+        }
+
+        /**
+         * Increment rate limit statistics for daily digest reporting.
+         *
+         * @param string $stat Statistic key (sent or blocked).
+         * @param int    $ttl  Statistic lifetime in seconds.
+         * @return void
+         */
+        private static function increment_rate_stat( string $stat, int $ttl = DAY_IN_SECONDS ): void {
+                $key = "rate_stat_{$stat}";
+
+                $current = PerformanceCache::get_cache_by_pattern( $key, 'email_rate_stats' );
+
+                if ( is_array( $current ) ) {
+                        $current = $current[ $key ] ?? 0;
+                }
+
+                $current = is_numeric( $current ) ? (int) $current : 0;
+
+                PerformanceCache::set_cache_by_pattern( $key, 'email_rate_stats', $current + 1, $ttl );
+        }
+
+        /**
+         * Retrieve aggregated rate limit statistics.
+         *
+         * @return array{sent:int,blocked:int} Rate limit stats for the current period.
+         */
+        private static function get_rate_limit_stats(): array {
+                $stats = PerformanceCache::get_cache_by_pattern( 'rate_stat_*', 'email_rate_stats' );
+
+                if ( ! is_array( $stats ) ) {
+                        return [ 'sent' => 0, 'blocked' => 0 ];
+                }
+
+                return [
+                        'sent' => isset( $stats['rate_stat_sent'] ) ? (int) $stats['rate_stat_sent'] : 0,
+                        'blocked' => isset( $stats['rate_stat_blocked'] ) ? (int) $stats['rate_stat_blocked'] : 0,
+                ];
+        }
 
 	/**
 	 * Get alert recipients
@@ -653,23 +698,33 @@ class EmailNotifications {
 			return;
 		}
 
-		// Gather daily statistics
-		$cache_stats = PerformanceCache::get_cache_stats();
+                // Gather daily statistics
+                $cache_stats = PerformanceCache::get_cache_stats();
+                $email_stats = self::get_rate_limit_stats();
+                $total_attempts = $email_stats['sent'] + $email_stats['blocked'];
+                $email_hit_ratio = $total_attempts > 0
+                        ? round( ( $email_stats['sent'] / $total_attempts ) * 100, 2 )
+                        : 100.0;
 
-		$digest_data = [
-			'report_type' => 'daily_digest',
-			'date' => current_time( 'Y-m-d' ),
+                $digest_data = [
+                        'report_type' => 'daily_digest',
+                        'date' => current_time( 'Y-m-d' ),
 			'summary' => __( 'Here is your daily summary from FP Digital Marketing Suite.', 'fp-digital-marketing' ),
 			'metrics' => [
-				'Cache Performance' => [
-					'current' => $cache_stats['hit_ratio'] ?? 0,
-					'previous' => 'N/A',
-					'change' => 'N/A',
-				],
-				'Active Clients' => [
-					'current' => wp_count_posts( 'cliente' )->publish ?? 0,
-					'previous' => 'N/A',
-					'change' => 'N/A',
+                                'Cache Performance' => [
+                                        'current' => $cache_stats['hit_ratio'] ?? 0,
+                                        'previous' => 'N/A',
+                                        'change' => 'N/A',
+                                ],
+                                'Email Delivery' => [
+                                        'current' => $email_hit_ratio,
+                                        'previous' => 'N/A',
+                                        'change' => 'N/A',
+                                ],
+                                'Active Clients' => [
+                                        'current' => wp_count_posts( 'cliente' )->publish ?? 0,
+                                        'previous' => 'N/A',
+                                        'change' => 'N/A',
 				],
 				'Security Events' => [
 					'current' => count( Security::get_security_logs( 10 ) ),
@@ -679,7 +734,9 @@ class EmailNotifications {
 			]
 		];
 
-		$recipients = $settings['digest_recipients'] ?? [ get_option( 'admin_email' ) ];
-		self::send_report( 'daily_digest', $digest_data, $recipients );
-	}
+                $recipients = $settings['digest_recipients'] ?? [ get_option( 'admin_email' ) ];
+                self::send_report( 'daily_digest', $digest_data, $recipients );
+
+                PerformanceCache::clear_cache_by_pattern( 'rate_stat_*', 'email_rate_stats' );
+        }
 }

--- a/src/Helpers/PerformanceCache.php
+++ b/src/Helpers/PerformanceCache.php
@@ -52,10 +52,15 @@ class PerformanceCache {
 	 */
 	private const OPTION_CACHE_SETTINGS = 'fp_digital_marketing_cache_settings';
 
-	/**
-	 * Benchmark data option name
-	 */
-	private const OPTION_BENCHMARK_DATA = 'fp_digital_marketing_benchmark_data';
+        /**
+         * Benchmark data option name
+         */
+        private const OPTION_BENCHMARK_DATA = 'fp_digital_marketing_benchmark_data';
+
+        /**
+         * Cache index option name used for pattern lookups.
+         */
+        private const OPTION_CACHE_INDEX = 'fp_digital_marketing_cache_index';
 
 	/**
 	 * Get cache settings
@@ -183,20 +188,25 @@ class PerformanceCache {
                         return false;
                 }
 
-		$settings = self::get_cache_settings();
-		$ttl = $ttl ?? $settings['default_ttl'];
+                $settings = self::get_cache_settings();
+                $ttl = $ttl ?? $settings['default_ttl'];
+                $ttl = (int) max( 0, $ttl );
 
-		$success = true;
+                $success = true;
 
-		// Store in object cache
-		if ( $settings['use_object_cache'] ) {
-			$success = wp_cache_set( $key, $data, $group, $ttl ) && $success;
-		}
+                // Store in object cache
+                if ( $settings['use_object_cache'] ) {
+                        $success = wp_cache_set( $key, $data, $group, $ttl ) && $success;
+                }
 
-		// Store in transients
-		if ( $settings['use_transients'] ) {
-			$transient_key = self::get_transient_key( $key, $group );
-			$success = set_transient( $transient_key, $data, $ttl ) && $success;
+                // Store in transients
+                if ( $settings['use_transients'] ) {
+                        $transient_key = self::get_transient_key( $key, $group );
+                        $success = set_transient( $transient_key, $data, $ttl ) && $success;
+                }
+
+                if ( $settings['use_object_cache'] || $settings['use_transients'] ) {
+                        self::register_cache_key( $group, $key, $ttl );
                 }
 
                 return $success;
@@ -232,96 +242,113 @@ class PerformanceCache {
                 $transient_key = self::get_transient_key( $key, $group );
                 $success = delete_transient( $transient_key ) && $success;
 
+                self::unregister_cache_key( $group, $key );
+
                 return $success;
+        }
+
+        /**
+         * Store cached data using a readable pattern-based key.
+         *
+         * @param string   $pattern Readable cache key or pattern without the group prefix.
+         * @param string   $group   Cache group name.
+         * @param mixed    $data    Data to cache.
+         * @param int|null $ttl     Time to live in seconds.
+         * @return bool Success status
+         */
+        public static function set_cache_by_pattern( string $pattern, string $group, $data, ?int $ttl = null ): bool {
+                $key = self::sanitize_cache_key( $pattern );
+
+                if ( '' === $key ) {
+                        $key = 'cache_' . md5( $pattern );
+                }
+
+                return self::set_cached( $key, $group, $data, $ttl );
+        }
+
+        /**
+         * Retrieve cached data using a pattern.
+         *
+         * When wildcards are provided the method returns an associative array of key/value pairs
+         * matching the pattern. Without wildcards it behaves like {@see self::get_cached()}.
+         *
+         * @param string        $pattern  Cache key or wildcard pattern
+         * @param string        $group    Cache group name
+         * @param callable|null $callback Optional callback for cache misses (exact keys only)
+         * @param int|null      $ttl      Optional TTL for callback-generated values
+         * @return mixed Cached value, array of matches, or null when nothing is found
+         */
+        public static function get_cache_by_pattern( string $pattern, string $group, ?callable $callback = null, ?int $ttl = null ) {
+                list( $normalized_pattern, $normalized_group ) = self::normalize_group_and_pattern( $pattern, $group );
+
+                if ( '' === $normalized_pattern ) {
+                        return $callback ? $callback() : null;
+                }
+
+                $has_wildcards = self::contains_wildcards( $normalized_pattern );
+
+                if ( ! $has_wildcards ) {
+                        $key = self::sanitize_cache_key( $normalized_pattern );
+                        if ( '' === $key ) {
+                                return $callback ? $callback() : null;
+                        }
+
+                        return self::get_cached( $key, $normalized_group, $callback, $ttl );
+                }
+
+                $matched_keys = self::find_keys_by_pattern( $normalized_group, $normalized_pattern );
+
+                if ( empty( $matched_keys ) ) {
+                        return [];
+                }
+
+                $results = [];
+                foreach ( $matched_keys as $matched_key ) {
+                        $value = wp_cache_get( $matched_key, $normalized_group );
+                        if ( false === $value ) {
+                                $value = get_transient( self::get_transient_key( $matched_key, $normalized_group ) );
+                        }
+
+                        if ( false !== $value ) {
+                                $results[ $matched_key ] = $value;
+                        }
+                }
+
+                return $results;
         }
 
         /**
          * Clear cache entries matching a wildcard pattern.
          *
          * @param string      $pattern Pattern supporting `*` and `?` wildcards
-         * @param string|null $group   Optional cache group for object cache invalidation
+         * @param string|null $group   Cache group name. When omitted the group will be inferred when possible.
          * @return void
          */
         public static function clear_cache_by_pattern( string $pattern, ?string $group = null ): void {
-                global $wpdb;
+                list( $normalized_pattern, $normalized_group ) = self::normalize_group_and_pattern( $pattern, $group );
 
-                $patterns = [ $pattern ];
-                $has_transient_prefix = false !== strpos( $pattern, '_transient_' );
-                $has_site_transient_prefix = false !== strpos( $pattern, '_site_transient_' );
-
-                if ( $has_transient_prefix || $has_site_transient_prefix ) {
-                        if ( $has_transient_prefix ) {
-                                $patterns[] = str_replace( '_transient_timeout_', '_transient_', $pattern );
-                                $patterns[] = str_replace( '_transient_', '_transient_timeout_', $pattern );
-                        }
-
-                        if ( $has_site_transient_prefix ) {
-                                $patterns[] = str_replace( '_site_transient_timeout_', '_site_transient_', $pattern );
-                                $patterns[] = str_replace( '_site_transient_', '_site_transient_timeout_', $pattern );
-                        }
-                } else {
-                        $patterns = [
-                                '_transient_' . $pattern,
-                                '_transient_timeout_' . $pattern,
-                                '_site_transient_' . $pattern,
-                                '_site_transient_timeout_' . $pattern,
-                        ];
-                }
-
-                $transient_keys = [];
-
-                foreach ( array_unique( $patterns ) as $like_pattern ) {
-                        $like = self::wildcard_to_like( $like_pattern );
-                        $option_names = $wpdb->get_col(
-                                $wpdb->prepare(
-                                        "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s",
-                                        $like
-                                )
-                        );
-
-                        if ( empty( $option_names ) ) {
-                                continue;
-                        }
-
-                        foreach ( $option_names as $option_name ) {
-                                if ( 0 === strpos( $option_name, '_transient_timeout_' ) ) {
-                                        $transient_keys[ substr( $option_name, strlen( '_transient_timeout_' ) ) ] = true;
-                                        continue;
-                                }
-
-                                if ( 0 === strpos( $option_name, '_transient_' ) ) {
-                                        $transient_keys[ substr( $option_name, strlen( '_transient_' ) ) ] = true;
-                                        continue;
-                                }
-
-                                if ( 0 === strpos( $option_name, '_site_transient_timeout_' ) ) {
-                                        $transient_keys[ substr( $option_name, strlen( '_site_transient_timeout_' ) ) ] = true;
-                                        continue;
-                                }
-
-                                if ( 0 === strpos( $option_name, '_site_transient_' ) ) {
-                                        $transient_keys[ substr( $option_name, strlen( '_site_transient_' ) ) ] = true;
-                                }
-                        }
-                }
-
-                if ( empty( $transient_keys ) ) {
-                        if ( $group ) {
-                                self::invalidate_object_cache_entries( $group, [] );
-                        }
-
+                if ( '' === $normalized_pattern ) {
                         return;
                 }
 
-                $transient_names = array_keys( $transient_keys );
+                $normalized_group = $normalized_group ?? self::infer_group_from_pattern( $normalized_pattern );
 
-                foreach ( $transient_names as $transient_key ) {
-                        delete_transient( $transient_key );
+                if ( empty( $normalized_group ) ) {
+                        return;
                 }
 
-                if ( $group ) {
-                        self::invalidate_object_cache_entries( $group, $transient_names );
+                $matched_keys = self::find_keys_by_pattern( $normalized_group, $normalized_pattern );
+
+                if ( empty( $matched_keys ) ) {
+                        self::bump_cache_version( $normalized_group );
+                        return;
                 }
+
+                foreach ( $matched_keys as $matched_key ) {
+                        self::delete_cached( $matched_key, $normalized_group );
+                }
+
+                self::bump_cache_version( $normalized_group );
         }
 
 	/**
@@ -330,33 +357,11 @@ class PerformanceCache {
 	 * @param string $group Cache group to invalidate
 	 * @return bool Success status
 	 */
-	public static function invalidate_group( string $group ): bool {
-		global $wpdb;
+        public static function invalidate_group( string $group ): bool {
+                self::clear_cache_by_pattern( '*', $group );
 
-		$success = true;
-
-		// For object cache, we'll use a group version increment
-		$version_key = "cache_version_{$group}";
-		$current_version = wp_cache_get( $version_key, 'cache_versions' );
-		$new_version = $current_version ? $current_version + 1 : 1;
-		wp_cache_set( $version_key, $new_version, 'cache_versions' );
-
-		// For transients, delete all transients with the group prefix
-		$transient_prefix = "fp_dms_{$group}_";
-		$transients = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s",
-				'_transient_' . $transient_prefix . '%'
-			)
-		);
-
-		foreach ( $transients as $transient ) {
-			$key = str_replace( '_transient_', '', $transient );
-			delete_transient( $key );
-		}
-
-		return $success;
-	}
+                return true;
+        }
 
 	/**
 	 * Invalidate all caches
@@ -513,13 +518,29 @@ class PerformanceCache {
 	 * @return string Cache key
 	 */
         public static function generate_report_key( int $client_id, string $report_type, array $params = [] ): string {
-                $key_data = [
-                        'client_id' => $client_id,
-                        'type' => $report_type,
-                        'params' => $params,
-                ];
-                ksort( $key_data );
-                return 'report_' . md5( serialize( $key_data ) );
+                $client_component = self::normalize_key_component( $client_id );
+                if ( '' === $client_component ) {
+                        $client_component = 'global';
+                }
+
+                $type_component = self::normalize_key_component( $report_type );
+                if ( '' === $type_component ) {
+                        $type_component = 'general';
+                }
+
+                $base_key = sprintf(
+                        'report_client_%s_type_%s',
+                        $client_component,
+                        $type_component
+                );
+
+                if ( empty( $params ) ) {
+                        return $base_key;
+                }
+
+                ksort( $params );
+
+                return $base_key . '_' . md5( serialize( $params ) );
         }
 
         /**
@@ -533,22 +554,349 @@ class PerformanceCache {
         }
 
         /**
-         * Invalidate object cache entries derived from transient names.
+         * Normalize the pattern/group combination accounting for swapped parameters.
          *
-         * @param string $group           Cache group name
-         * @param array  $transient_names Transient identifiers without prefix
+         * @param string      $pattern Raw pattern or group identifier.
+         * @param string|null $group   Cache group or pattern depending on call order.
+         * @return array{0:string,1:?string} Normalized pattern and group.
+         */
+        private static function normalize_group_and_pattern( string $pattern, ?string $group ): array {
+                $pattern_to_use = $pattern;
+                $group_to_use = $group;
+
+                if ( null !== $group && ! self::contains_wildcards( (string) $pattern ) && self::contains_wildcards( (string) $group ) ) {
+                        $pattern_to_use = $group;
+                        $group_to_use = $pattern;
+                }
+
+                return [ self::normalize_pattern( $pattern_to_use ), $group_to_use ];
+        }
+
+        /**
+         * Determine if a pattern contains wildcard tokens.
+         *
+         * @param string $pattern Pattern string.
+         * @return bool Whether wildcards are present.
+         */
+        private static function contains_wildcards( string $pattern ): bool {
+                return strpbrk( $pattern, '*?' ) !== false;
+        }
+
+        /**
+         * Sanitize cache keys used for storage.
+         *
+         * @param string $key Raw cache key.
+         * @return string Sanitized key.
+         */
+        private static function sanitize_cache_key( string $key ): string {
+                $key = trim( (string) $key );
+                if ( '' === $key ) {
+                        return '';
+                }
+
+                $key = preg_replace( '/\s+/', '_', $key );
+                $key = preg_replace( '/[^A-Za-z0-9:_\-]+/', '_', $key );
+                $key = preg_replace( '/_+/', '_', $key );
+
+                return trim( (string) $key, '_' );
+        }
+
+        /**
+         * Normalize patterns while preserving wildcard tokens.
+         *
+         * @param string $pattern Pattern string.
+         * @return string Normalized pattern.
+         */
+        private static function normalize_pattern( string $pattern ): string {
+                $pattern = trim( (string) $pattern );
+                if ( '' === $pattern ) {
+                        return '';
+                }
+
+                $pattern = preg_replace( '/\s+/', '_', $pattern );
+                $pattern = preg_replace( '/[^A-Za-z0-9:_\-\*\?]+/', '_', $pattern );
+                $pattern = preg_replace( '/_+/', '_', $pattern );
+
+                return trim( (string) $pattern, '_' );
+        }
+
+        /**
+         * Locate cache keys that match a pattern within a group.
+         *
+         * @param string $group   Cache group name.
+         * @param string $pattern Normalized pattern string.
+         * @return array<int,string> Matching cache keys.
+         */
+        private static function find_keys_by_pattern( string $group, string $pattern ): array {
+                $keys = [];
+
+                $index = self::load_cache_index();
+                if ( isset( $index[ $group ] ) && is_array( $index[ $group ] ) ) {
+                        foreach ( array_keys( $index[ $group ] ) as $cached_key ) {
+                                if ( self::wildcard_match( $pattern, (string) $cached_key ) ) {
+                                        $keys[ $cached_key ] = true;
+                                }
+                        }
+                }
+
+                foreach ( self::get_matching_transient_keys( $group, $pattern ) as $transient_key ) {
+                        $keys[ $transient_key ] = true;
+                }
+
+                return array_keys( $keys );
+        }
+
+        /**
+         * Retrieve transient identifiers matching the provided pattern.
+         *
+         * @param string $group   Cache group name.
+         * @param string $pattern Normalized pattern string.
+         * @return array<int,string> Matching cache keys (without prefix).
+         */
+        private static function get_matching_transient_keys( string $group, string $pattern ): array {
+                global $wpdb;
+
+                if ( '' === $group ) {
+                        return [];
+                }
+
+                $prefixed_pattern = self::get_prefixed_pattern( $group, $pattern );
+                $option_patterns = [
+                        '_transient_' . $prefixed_pattern,
+                        '_transient_timeout_' . $prefixed_pattern,
+                        '_site_transient_' . $prefixed_pattern,
+                        '_site_transient_timeout_' . $prefixed_pattern,
+                ];
+
+                $keys = [];
+                foreach ( array_unique( $option_patterns ) as $option_pattern ) {
+                        $like = self::wildcard_to_like( $option_pattern );
+                        $option_names = $wpdb->get_col(
+                                $wpdb->prepare(
+                                        "SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE %s",
+                                        $like
+                                )
+                        );
+
+                        foreach ( $option_names as $option_name ) {
+                                $extracted = self::extract_transient_key( $option_name, $group );
+                                if ( null === $extracted ) {
+                                        continue;
+                                }
+
+                                if ( self::wildcard_match( $pattern, $extracted ) ) {
+                                        $keys[] = $extracted;
+                                }
+                        }
+                }
+
+                return array_values( array_unique( $keys ) );
+        }
+
+        /**
+         * Build the transient pattern prefix for a group.
+         *
+         * @param string $group   Cache group name.
+         * @param string $pattern Pattern string.
+         * @return string Prefixed pattern for transient lookups.
+         */
+        private static function get_prefixed_pattern( string $group, string $pattern ): string {
+                $prefix = 'fp_dms_' . $group . '_';
+
+                if ( strpos( $pattern, $prefix ) === 0 ) {
+                        return $pattern;
+                }
+
+                return $prefix . $pattern;
+        }
+
+        /**
+         * Extract a cache key from an option entry.
+         *
+         * @param string $option_name Raw option name.
+         * @param string $group       Cache group name.
+         * @return string|null Cache key without prefix or null when not applicable.
+         */
+        private static function extract_transient_key( string $option_name, string $group ): ?string {
+                $prefixes = [
+                        '_transient_',
+                        '_transient_timeout_',
+                        '_site_transient_',
+                        '_site_transient_timeout_',
+                ];
+
+                foreach ( $prefixes as $prefix ) {
+                        if ( strpos( $option_name, $prefix ) === 0 ) {
+                                $transient_name = substr( $option_name, strlen( $prefix ) );
+                                $expected_prefix = 'fp_dms_' . $group . '_';
+
+                                if ( strpos( $transient_name, $expected_prefix ) === 0 ) {
+                                        return substr( $transient_name, strlen( $expected_prefix ) );
+                                }
+
+                                return null;
+                        }
+                }
+
+                return null;
+        }
+
+        /**
+         * Perform wildcard matching using regular expressions (case-insensitive).
+         *
+         * @param string $pattern Pattern string.
+         * @param string $value   Value to test.
+         * @return bool True when the value matches the pattern.
+         */
+        private static function wildcard_match( string $pattern, string $value ): bool {
+                $regex = '/^' . str_replace( [ '\\*', '\\?' ], [ '.*', '.' ], preg_quote( strtolower( $pattern ), '/' ) ) . '$/';
+
+                return (bool) preg_match( $regex, strtolower( $value ) );
+        }
+
+        /**
+         * Load the cache index used for pattern lookups.
+         *
+         * @param bool $cleanup Whether to remove expired entries.
+         * @return array<string,array<string,int>> Cache index grouped by cache group.
+         */
+        private static function load_cache_index( bool $cleanup = true ): array {
+                $index = get_option( self::OPTION_CACHE_INDEX, [] );
+                if ( ! is_array( $index ) ) {
+                        $index = [];
+                }
+
+                if ( ! $cleanup ) {
+                        return $index;
+                }
+
+                $changed = false;
+                $now = time();
+
+                foreach ( $index as $group => $keys ) {
+                        if ( ! is_array( $keys ) ) {
+                                unset( $index[ $group ] );
+                                $changed = true;
+                                continue;
+                        }
+
+                        foreach ( $keys as $key => $expires_at ) {
+                                if ( is_int( $expires_at ) && $expires_at > 0 && $expires_at <= $now ) {
+                                        unset( $index[ $group ][ $key ] );
+                                        $changed = true;
+                                }
+                        }
+
+                        if ( empty( $index[ $group ] ) ) {
+                                unset( $index[ $group ] );
+                                $changed = true;
+                        }
+                }
+
+                if ( $changed ) {
+                        self::save_cache_index( $index );
+                }
+
+                return $index;
+        }
+
+        /**
+         * Persist the cache index.
+         *
+         * @param array<string,array<string,int>> $index Cache index data.
          * @return void
          */
-        private static function invalidate_object_cache_entries( string $group, array $transient_names ): void {
-                $group_prefix = "fp_dms_{$group}_";
+        private static function save_cache_index( array $index ): void {
+                update_option( self::OPTION_CACHE_INDEX, $index, false );
+        }
 
-                foreach ( $transient_names as $transient_name ) {
-                        if ( strpos( $transient_name, $group_prefix ) === 0 ) {
-                                $cache_key = substr( $transient_name, strlen( $group_prefix ) );
-                                wp_cache_delete( $cache_key, $group );
-                        } else {
-                                wp_cache_delete( $transient_name, $group );
+        /**
+         * Register a cache key for pattern-based operations.
+         *
+         * @param string $group Cache group name.
+         * @param string $key   Cache key.
+         * @param int    $ttl   Time to live in seconds.
+         * @return void
+         */
+        private static function register_cache_key( string $group, string $key, int $ttl ): void {
+                if ( '' === $group || '' === $key ) {
+                        return;
+                }
+
+                $index = self::load_cache_index();
+
+                if ( ! isset( $index[ $group ] ) || ! is_array( $index[ $group ] ) ) {
+                        $index[ $group ] = [];
+                }
+
+                $expiration = $ttl > 0 ? time() + $ttl : 0;
+                $index[ $group ][ $key ] = $expiration;
+
+                if ( count( $index[ $group ] ) > 500 ) {
+                        $index[ $group ] = array_slice( $index[ $group ], -500, null, true );
+                }
+
+                self::save_cache_index( $index );
+        }
+
+        /**
+         * Unregister a cache key from the pattern index.
+         *
+         * @param string $group Cache group name.
+         * @param string $key   Cache key.
+         * @return void
+         */
+        private static function unregister_cache_key( string $group, string $key ): void {
+                if ( '' === $group || '' === $key ) {
+                        return;
+                }
+
+                $index = self::load_cache_index();
+
+                if ( isset( $index[ $group ][ $key ] ) ) {
+                        unset( $index[ $group ][ $key ] );
+
+                        if ( empty( $index[ $group ] ) ) {
+                                unset( $index[ $group ] );
                         }
+
+                        self::save_cache_index( $index );
+                }
+        }
+
+        /**
+         * Attempt to infer the cache group from a pattern when one is not provided.
+         *
+         * @param string $pattern Normalized pattern string.
+         * @return string|null Cache group name when identifiable.
+         */
+        private static function infer_group_from_pattern( string $pattern ): ?string {
+                $index = self::load_cache_index( false );
+                $known_groups = array_unique( array_merge( [
+                        self::CACHE_GROUP_METRICS,
+                        self::CACHE_GROUP_REPORTS,
+                        self::CACHE_GROUP_AGGREGATED,
+                ], array_keys( $index ) ) );
+
+                foreach ( $known_groups as $candidate ) {
+                        $prefix = 'fp_dms_' . $candidate . '_';
+                        if ( strpos( $pattern, $prefix ) === 0 ) {
+                                return $candidate;
+                        }
+                }
+
+                return null;
+        }
+
+        /**
+         * Increment the cache version for a group to invalidate object cache entries.
+         *
+         * @param string $group Cache group name.
+         * @return void
+         */
+        private static function bump_cache_version( string $group ): void {
+                if ( '' === $group ) {
+                        return;
                 }
 
                 $version_key = "cache_version_{$group}";

--- a/src/Helpers/ReportGenerator.php
+++ b/src/Helpers/ReportGenerator.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace FP\DigitalMarketing\Helpers;
 
+use FP\DigitalMarketing\Tools\Exports\CsvExporter;
+
 use Dompdf\Dompdf;
 use Dompdf\Options;
 use FP\DigitalMarketing\Models\MetricsCache;
@@ -332,17 +334,23 @@ class ReportGenerator {
 	 */
 	private static function array_to_csv( array $data, string $separator = ',' ): string {
 		$output = fopen( 'php://temp', 'r+' );
-		
-		foreach ( $data as $row ) {
-			fputcsv( $output, $row, $separator );
+
+		if ( false === $output ) {
+			return '';
 		}
-		
+
+		fwrite( $output, "\xEF\xBB\xBF" );
+
+		foreach ( $data as $row ) {
+			$row_data = is_array( $row ) ? $row : (array) $row;
+			CsvExporter::write_row( $output, $row_data, $separator );
+		}
+
 		rewind( $output );
 		$csv_content = stream_get_contents( $output );
 		fclose( $output );
-		
-		// Ensure UTF-8 encoding
-		return "\xEF\xBB\xBF" . $csv_content; // Add BOM for UTF-8
+
+		return is_string( $csv_content ) ? $csv_content : '';
 	}
 
 	/**

--- a/src/Models/ConversionEvent.php
+++ b/src/Models/ConversionEvent.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace FP\DigitalMarketing\Models;
 
 use FP\DigitalMarketing\Database\ConversionEventsTable;
+use FP\DigitalMarketing\Helpers\PerformanceCache;
 
 /**
  * Conversion Event model class
@@ -325,19 +326,26 @@ class ConversionEvent {
 		$data = $this->to_array();
 		unset( $data['id'] ); // Don't include ID in insert/update data
 
-		if ( $this->id ) {
-			// Update existing event
-			return ConversionEventsTable::update_event( $this->id, $data );
-		} else {
-			// Insert new event
-			$insert_id = ConversionEventsTable::insert_event( $data );
-			if ( $insert_id ) {
-				$this->id = $insert_id;
-				return true;
-			}
-			return false;
-		}
-	}
+                $result = false;
+
+                if ( $this->id ) {
+                        // Update existing event
+                        $result = ConversionEventsTable::update_event( $this->id, $data );
+                } else {
+                        // Insert new event
+                        $insert_id = ConversionEventsTable::insert_event( $data );
+                        if ( $insert_id ) {
+                                $this->id = $insert_id;
+                                $result = true;
+                        }
+                }
+
+                if ( $result ) {
+                        $this->invalidate_cache();
+                }
+
+                return (bool) $result;
+        }
 
 	/**
 	 * Delete event from database
@@ -349,8 +357,14 @@ class ConversionEvent {
 			return false;
 		}
 
-		return ConversionEventsTable::delete_event( $this->id );
-	}
+                $result = ConversionEventsTable::delete_event( $this->id );
+
+                if ( $result ) {
+                        $this->invalidate_cache();
+                }
+
+                return $result;
+        }
 
 	/**
 	 * Mark this event as duplicate
@@ -406,13 +420,32 @@ class ConversionEvent {
 	 * @param mixed  $value Attribute value
 	 * @return void
 	 */
-	public function set_attribute( string $key, $value ): void {
-		$this->event_attributes[ $key ] = $value;
-	}
+        public function set_attribute( string $key, $value ): void {
+                $this->event_attributes[ $key ] = $value;
+        }
 
-	/**
-	 * Convert to array representation
-	 *
+        /**
+         * Clear cached metrics related to this conversion event.
+         *
+         * @return void
+         */
+        private function invalidate_cache(): void {
+                $client_component = $this->client_id > 0 ? (string) $this->client_id : 'global';
+
+                $patterns = [
+                        PerformanceCache::CACHE_GROUP_METRICS => sprintf( 'metrics_client_%s_*', $client_component ),
+                        PerformanceCache::CACHE_GROUP_AGGREGATED => sprintf( 'metrics_client_%s_*', $client_component ),
+                        PerformanceCache::CACHE_GROUP_REPORTS => sprintf( 'report_client_%s_*', $client_component ),
+                ];
+
+                foreach ( $patterns as $group => $pattern ) {
+                        PerformanceCache::clear_cache_by_pattern( $pattern, $group );
+                }
+        }
+
+        /**
+         * Convert to array representation
+         *
 	 * @return array Event data as array
 	 */
 	public function to_array(): array {

--- a/src/Performance/BenchmarkMath.php
+++ b/src/Performance/BenchmarkMath.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Benchmark Math utilities.
+ *
+ * @package FP_Digital_Marketing_Suite
+ */
+
+declare(strict_types=1);
+
+namespace FP\DigitalMarketing\Performance;
+
+/**
+ * Helper providing safe mathematical helpers for benchmark calculations.
+ */
+class BenchmarkMath {
+
+	/**
+	 * Safely divide two numbers, avoiding division by zero.
+	 *
+	 * @param mixed $numerator   Numerator value.
+	 * @param mixed $denominator Denominator value.
+	 * @param float $default     Default value when division is not possible.
+	 * @return float Result of the division or the provided default.
+	 */
+	public static function safe_divide( $numerator, $denominator, float $default = 0.0 ): float {
+		if ( ! is_numeric( $numerator ) || ! is_numeric( $denominator ) ) {
+			return $default;
+		}
+
+		$denominator = (float) $denominator;
+
+		if ( 0.0 === $denominator ) {
+			return $default;
+		}
+
+		return (float) $numerator / $denominator;
+	}
+
+	/**
+	 * Calculate the average of a list of values safely.
+	 *
+	 * @param array $values  Values to average.
+	 * @param float $default Default value when no numeric values are present.
+	 * @return float Average value.
+	 */
+	public static function average( array $values, float $default = 0.0 ): float {
+		$numeric_values = self::filter_numeric_values( $values );
+
+		if ( empty( $numeric_values ) ) {
+			return $default;
+		}
+
+		$sum = array_sum( $numeric_values );
+
+		return self::safe_divide( $sum, count( $numeric_values ), $default );
+	}
+
+	/**
+	 * Calculate a percentage safely.
+	 *
+	 * @param mixed $portion Portion value.
+	 * @param mixed $total   Total value.
+	 * @param float $default Default percentage when calculation is not possible.
+	 * @return float Percentage value.
+	 */
+	public static function safe_percentage( $portion, $total, float $default = 0.0 ): float {
+		return self::safe_divide( $portion, $total, $default ) * 100;
+	}
+
+	/**
+	 * Get the minimum numeric value from the array.
+	 *
+	 * @param array $values  Values to inspect.
+	 * @param float $default Default value when no numeric values are present.
+	 * @return float Minimum value.
+	 */
+	public static function min( array $values, float $default = 0.0 ): float {
+		$numeric_values = self::filter_numeric_values( $values );
+
+		if ( empty( $numeric_values ) ) {
+			return $default;
+		}
+
+		return (float) min( $numeric_values );
+	}
+
+	/**
+	 * Get the maximum numeric value from the array.
+	 *
+	 * @param array $values  Values to inspect.
+	 * @param float $default Default value when no numeric values are present.
+	 * @return float Maximum value.
+	 */
+	public static function max( array $values, float $default = 0.0 ): float {
+		$numeric_values = self::filter_numeric_values( $values );
+
+		if ( empty( $numeric_values ) ) {
+			return $default;
+		}
+
+		return (float) max( $numeric_values );
+	}
+
+	/**
+	 * Normalize an array ensuring only numeric values are retained.
+	 *
+	 * @param array $values Values to filter.
+	 * @return array<float> Numeric values.
+	 */
+	private static function filter_numeric_values( array $values ): array {
+		$numeric_values = [];
+
+		foreach ( $values as $value ) {
+			if ( is_numeric( $value ) ) {
+				$numeric_values[] = (float) $value;
+			}
+		}
+
+		return $numeric_values;
+	}
+}

--- a/src/Tools/Exports/CsvExporter.php
+++ b/src/Tools/Exports/CsvExporter.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * CSV Export utilities.
+ *
+ * @package FP_Digital_Marketing_Suite
+ */
+
+declare(strict_types=1);
+
+namespace FP\DigitalMarketing\Tools\Exports;
+
+/**
+ * Helper class providing safe CSV export helpers.
+ */
+class CsvExporter {
+
+	/**
+	 * Sanitize a single CSV value to avoid injection issues.
+	 *
+	 * @param mixed $value Value to sanitize.
+	 * @return string Sanitized string representation.
+	 */
+	public static function sanitize_value( $value ): string {
+		if ( is_array( $value ) || is_object( $value ) ) {
+			$encoder = function_exists( 'wp_json_encode' ) ? 'wp_json_encode' : 'json_encode';
+			$encoded = $encoder( $value );
+			$value = false !== $encoded ? $encoded : '';
+		} elseif ( is_bool( $value ) ) {
+			$value = $value ? '1' : '0';
+		} elseif ( null === $value ) {
+			$value = '';
+		}
+
+		$value = (string) $value;
+
+		if ( function_exists( 'wp_strip_all_tags' ) ) {
+			$value = wp_strip_all_tags( $value );
+		} else {
+			$value = strip_tags( $value );
+		}
+
+		$value = str_replace( [ "\r", "\n", "\t" ], ' ', $value );
+		$value = trim( $value );
+
+		if ( '' !== $value && in_array( $value[0], [ '=', '+', '-', '@' ], true ) ) {
+			$value = "'" . $value;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Sanitize an entire CSV row.
+	 *
+	 * @param array $row Row values.
+	 * @return array Sanitized values.
+	 */
+	public static function sanitize_row( array $row ): array {
+		return array_map( [ __CLASS__, 'sanitize_value' ], $row );
+	}
+
+	/**
+	 * Write a sanitized row to a CSV handle.
+	 *
+	 * @param resource $handle    Output handle.
+	 * @param array    $row       Row values.
+	 * @param string   $separator Field separator.
+	 * @return void
+	 */
+	public static function write_row( $handle, array $row, string $separator = ',' ): void {
+		if ( ! is_resource( $handle ) ) {
+			return;
+		}
+
+		fputcsv( $handle, self::sanitize_row( $row ), $separator );
+	}
+
+	/**
+	 * Convert a row to a CSV string.
+	 *
+	 * @param array  $row       Row values.
+	 * @param string $separator Field separator.
+	 * @return string CSV string without trailing newline.
+	 */
+	public static function row_to_csv( array $row, string $separator = ',' ): string {
+		$temp = fopen( 'php://temp', 'r+' );
+		if ( false === $temp ) {
+			return '';
+		}
+
+		self::write_row( $temp, $row, $separator );
+		rewind( $temp );
+
+		$line = stream_get_contents( $temp );
+		fclose( $temp );
+
+		if ( false === $line ) {
+			return '';
+		}
+
+		return rtrim( $line, "\r\n" );
+	}
+}

--- a/tests/DataExporterTest.php
+++ b/tests/DataExporterTest.php
@@ -137,28 +137,60 @@ class DataExporterTest extends TestCase {
 	 *
 	 * @return void
 	 */
-	public function test_csv_content_generation(): void {
-		$reflection = new ReflectionClass( DataExporter::class );
-		$method = $reflection->getMethod( 'generate_csv_content' );
-		$method->setAccessible( true );
+        public function test_csv_content_generation(): void {
+                $reflection = new ReflectionClass( DataExporter::class );
+                $method = $reflection->getMethod( 'generate_csv_content' );
+                $method->setAccessible( true );
 
-		$test_data = [
-			[ 'name' => 'John', 'age' => 30, 'city' => 'New York' ],
-			[ 'name' => 'Jane', 'age' => 25, 'city' => 'London' ],
-		];
+                $test_data = [
+                        [ 'name' => 'John', 'age' => 30, 'city' => 'New York' ],
+                        [ 'name' => 'Jane', 'age' => 25, 'city' => 'London' ],
+                ];
 
-		$csv_content = $method->invoke( null, $test_data );
+                $csv_content = $method->invoke( null, $test_data );
 
-		// Should contain BOM for UTF-8
-		$this->assertStringStartsWith( "\xEF\xBB\xBF", $csv_content );
-		
+                // Should contain BOM for UTF-8
+                $this->assertStringStartsWith( "\xEF\xBB\xBF", $csv_content );
+
                 // Should contain headers
                 $this->assertStringContainsString( 'name,age,city', $csv_content );
 
                 // Should contain data
                 $this->assertStringContainsString( 'John,30,"New York"', $csv_content );
                 $this->assertStringContainsString( 'Jane,25,London', $csv_content );
-	}
+        }
+
+        /**
+         * Ensure CSV generation sanitizes malicious values to prevent CSV injection.
+         *
+         * @return void
+         */
+        public function test_csv_content_sanitizes_malicious_values(): void {
+                $reflection = new ReflectionClass( DataExporter::class );
+                $method = $reflection->getMethod( 'generate_csv_content' );
+                $method->setAccessible( true );
+
+                $test_data = [
+                        [
+                                'name' => '=2+2',
+                                'notes' => "Line\n<script>alert('x')</script>",
+                        ],
+                ];
+
+                $csv_content = $method->invoke( null, $test_data );
+
+                $this->assertStringStartsWith( "\xEF\xBB\xBF", $csv_content );
+
+                $trimmed = str_replace( "\xEF\xBB\xBF", '', $csv_content );
+                $lines = array_values( array_filter( explode( "\n", trim( $trimmed ) ) ) );
+
+                $this->assertCount( 2, $lines );
+
+                $row = str_getcsv( $lines[1] );
+
+                $this->assertSame( "'=2+2", $row[0] );
+                $this->assertSame( "Line alert('x')", $row[1] );
+        }
 
 	/**
 	 * Test JSON content generation

--- a/tests/ReportGeneratorTest.php
+++ b/tests/ReportGeneratorTest.php
@@ -80,20 +80,54 @@ class ReportGeneratorTest extends TestCase {
 	/**
 	 * Test CSV report generation with custom separator
 	 */
-	public function test_generate_csv_report_custom_separator(): void {
-		$report_data = ReportGenerator::generate_demo_report_data( 1 );
-		$csv_content = ReportGenerator::generate_csv_report( $report_data, ';' );
+        public function test_generate_csv_report_custom_separator(): void {
+                $report_data = ReportGenerator::generate_demo_report_data( 1 );
+                $csv_content = ReportGenerator::generate_csv_report( $report_data, ';' );
 
-		$this->assertIsString( $csv_content );
-		$this->assertNotEmpty( $csv_content );
-		
-		// Check that semicolon is used as separator
-		$this->assertStringContainsString( ';', $csv_content );
-		
-		// Parse CSV to ensure it's valid
-		$lines = explode( "\n", trim( str_replace( "\xEF\xBB\xBF", '', $csv_content ) ) );
-		$this->assertGreaterThan( 5, count( $lines ) ); // Should have multiple lines
-	}
+                $this->assertIsString( $csv_content );
+                $this->assertNotEmpty( $csv_content );
+
+                // Check that semicolon is used as separator
+                $this->assertStringContainsString( ';', $csv_content );
+
+                // Parse CSV to ensure it's valid
+                $lines = explode( "\n", trim( str_replace( "\xEF\xBB\xBF", '', $csv_content ) ) );
+                $this->assertGreaterThan( 5, count( $lines ) ); // Should have multiple lines
+        }
+
+        /**
+         * Ensure generated CSV reports sanitize formula injections and markup.
+         */
+        public function test_generate_csv_report_sanitizes_values(): void {
+                $report_data = [
+                        'client_id' => 1,
+                        'period_start' => '2024-01-01',
+                        'period_end' => '2024-01-31',
+                        'generated_at' => '2024-01-01 12:00:00',
+                        'kpis' => [
+                                'sessions' => [
+                                        'value' => "=SUM(A1:A2)\n<script>alert('x')</script>",
+                                        'previous_value' => 100,
+                                        'change_percent' => 5,
+                                        'change_type' => 'increase',
+                                ],
+                        ],
+                        'channels' => [
+                                [
+                                        'name' => '<b>Direct</b>',
+                                        'sessions' => 200,
+                                        'revenue' => 300.5,
+                                ],
+                        ],
+                ];
+
+                $csv_content = ReportGenerator::generate_csv_report( $report_data );
+
+                $this->assertStringContainsString( "'=SUM(A1:A2) alert('x')", $csv_content );
+                $this->assertStringContainsString( 'Direct', $csv_content );
+                $this->assertStringNotContainsString( '<b>', $csv_content );
+                $this->assertStringNotContainsString( "=SUM(A1:A2)\n", $csv_content );
+        }
 
 	/**
 	 * Test report data validation


### PR DESCRIPTION
## Summary
- add pattern-aware cache helper methods with index tracking to support wildcard lookups and invalidations
- clear metrics and report caches when conversion data changes and tighten email rate-limit reporting and daily digest metrics
- introduce a reusable CSV exporter, integrate it with report and data exports, and add sanitization-focused tests
- add a benchmark math utility to prevent divide-by-zero errors and update monitoring admin scripts to enqueue `wp-util`

## Testing
- composer test *(fails: phpunit not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a907eba4832f9a7889d1f1e1e32b