### PR TITLE
Enhance metrics cache filtering and aggregator logic

### DIFF
--- a/src/Database/CustomReportsTable.php
+++ b/src/Database/CustomReportsTable.php
@@ -235,7 +235,7 @@ class CustomReportsTable {
 
 		$where_sql = implode( ' AND ', $where_clauses );
                 $order_sql = sprintf( 'ORDER BY %s %s', $order_by, $order_direction );
-		$limit_sql = sprintf( 'LIMIT %d OFFSET %d', $args['limit'], $args['offset'] );
+                $limit_sql = sprintf( 'LIMIT %d OFFSET %d', max( 0, (int) $args['limit'] ), max( 0, (int) $args['offset'] ) );
 
 		$query = $wpdb->prepare(
 			"SELECT * FROM " . self::get_table_name() . " WHERE {$where_sql} {$order_sql} {$limit_sql}",
@@ -289,7 +289,7 @@ class CustomReportsTable {
 
 		$where_sql = empty( $where_clauses ) ? '' : 'WHERE ' . implode( ' AND ', $where_clauses );
                 $order_sql = sprintf( 'ORDER BY %s %s', $order_by, $order_direction );
-		$limit_sql = sprintf( 'LIMIT %d OFFSET %d', $args['limit'], $args['offset'] );
+                $limit_sql = sprintf( 'LIMIT %d OFFSET %d', max( 0, (int) $args['limit'] ), max( 0, (int) $args['offset'] ) );
 
 		$query = "SELECT * FROM " . self::get_table_name() . " {$where_sql} {$order_sql} {$limit_sql}";
 

--- a/src/Helpers/MetricsAggregator.php
+++ b/src/Helpers/MetricsAggregator.php
@@ -116,11 +116,10 @@ class MetricsAggregator {
 	 */
 	private static function get_aggregated_metrics_uncached( int $client_id, string $period_start, string $period_end, array $kpis = [], array $sources = [] ): array {
 		try {
-			// Get raw metrics from cache
 			$criteria = [
-				'client_id' => $client_id,
+				'client_id'    => $client_id,
 				'period_start' => $period_start,
-				'period_end' => $period_end,
+				'period_end'   => $period_end,
 			];
 
 			if ( ! empty( $sources ) ) {
@@ -129,13 +128,11 @@ class MetricsAggregator {
 
 			$raw_metrics = MetricsCache::get_metrics( $criteria );
 
-			// Normalize and aggregate
 			$aggregated = [];
-			
+
 			foreach ( $raw_metrics as $metric ) {
 				$normalized_kpi = MetricsSchema::normalize_metric_name( $metric->source, $metric->metric );
-				
-				// Filter by requested KPIs if specified
+
 				if ( ! empty( $kpis ) && ! in_array( $normalized_kpi, $kpis, true ) ) {
 					continue;
 				}
@@ -150,38 +147,35 @@ class MetricsAggregator {
 					];
 				}
 
-			$value = is_numeric( $metric->value ) ? (float) $metric->value : 0;
-			$aggregated[ $normalized_kpi ]['values'][] = $value;
-			$aggregated[ $normalized_kpi ]['sources'][] = $metric->source;
-			$aggregated[ $normalized_kpi ]['count']++;
+				$value = is_numeric( $metric->value ) ? (float) $metric->value : 0.0;
+				$aggregated[ $normalized_kpi ]['values'][]  = $value;
+				$aggregated[ $normalized_kpi ]['sources'][] = $metric->source;
+				$aggregated[ $normalized_kpi ]['count']++;
+			}
 
-			// Apply aggregation method
-			$aggregation_method = MetricsSchema::get_aggregation_method( $normalized_kpi );
-			
-                        if ( $aggregation_method === 'sum' ) {
-                                $aggregated[ $normalized_kpi ]['total_value'] += $value;
-                        } elseif ( in_array( $aggregation_method, [ 'average', 'avg' ], true ) ) {
-                                if ( $aggregated[ $normalized_kpi ]['count'] > 0 ) {
-                                        $aggregated[ $normalized_kpi ]['total_value'] = array_sum( $aggregated[ $normalized_kpi ]['values'] ) / $aggregated[ $normalized_kpi ]['count'];
-                                }
-                        } elseif ( $aggregation_method === 'percentile_75' ) {
-                                $aggregated[ $normalized_kpi ]['total_value'] = self::calculate_percentile( $aggregated[ $normalized_kpi ]['values'], 0.75 );
-                        }
+			foreach ( $aggregated as $kpi => &$data ) {
+				$aggregation_method = MetricsSchema::get_aggregation_method( $kpi );
+
+				if ( in_array( $aggregation_method, [ 'average', 'avg' ], true ) ) {
+					$data['total_value'] = $data['count'] > 0 ? array_sum( $data['values'] ) / $data['count'] : 0.0;
+				} elseif ( 'percentile_75' === $aggregation_method ) {
+					$data['total_value'] = self::calculate_percentile( $data['values'], 0.75 );
+				} else {
+					$data['total_value'] = array_sum( $data['values'] );
+				}
+			}
+			unset( $data );
+
+			$aggregated = self::apply_fallbacks( $aggregated, $kpis );
+
+			return $aggregated;
+		} catch ( \Throwable $e ) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
+				error_log( 'FP Digital Marketing MetricsAggregator Uncached Error: ' . $e->getMessage() );
+			}
+
+			return self::apply_fallbacks( [], $kpis );
 		}
-
-		// Apply fallbacks for missing KPIs
-		$aggregated = self::apply_fallbacks( $aggregated, $kpis );
-
-		return $aggregated;
-	} catch ( \Throwable $e ) {
-		// Log error and return fallback data to prevent WSOD
-		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && function_exists( 'error_log' ) ) {
-			error_log( 'FP Digital Marketing MetricsAggregator Uncached Error: ' . $e->getMessage() );
-		}
-		
-		// Return fallback data with default values
-		return self::apply_fallbacks( [], $kpis );
-	}
 }
 
 	/**

--- a/src/Models/MetricsCache.php
+++ b/src/Models/MetricsCache.php
@@ -19,6 +19,20 @@ use FP\DigitalMarketing\Database\MetricsCacheTable;
  */
 class MetricsCache {
 
+        /**
+         * Columns that can be safely used for ORDER BY clauses.
+         *
+         * @var string[]
+         */
+        private const ORDERABLE_COLUMNS = [
+                'fetched_at',
+                'period_start',
+                'period_end',
+                'client_id',
+                'metric',
+                'source',
+        ];
+
 	/**
 	 * Save a metric record to the cache
 	 *
@@ -94,76 +108,71 @@ class MetricsCache {
 	 * @param array $args Query arguments
 	 * @return array Array of metric record objects
 	 */
-	public static function get_metrics( array $args = [] ): array {
-		global $wpdb;
+        public static function get_metrics( array $args = [] ): array {
+                global $wpdb;
 
-		$table_name = MetricsCacheTable::get_table_name();
+                $table_name = MetricsCacheTable::get_table_name();
 
-		$defaults = [
+                $defaults = [
 			'client_id'    => null,
 			'source'       => null,
 			'metric'       => null,
 			'period_start' => null,
 			'period_end'   => null,
 			'limit'        => 100,
-			'offset'       => 0,
-			'order_by'     => 'fetched_at',
-			'order'        => 'DESC',
-		];
-		$sortable_columns = [ 'fetched_at', 'period_start', 'period_end', 'client_id', 'metric', 'source' ];
-		$default_order_by = $defaults['order_by'];
-		$sanitized_default_order_by = sanitize_sql_orderby( $default_order_by );
-		if ( empty( $sanitized_default_order_by ) || ! in_array( $sanitized_default_order_by, $sortable_columns, true ) ) {
-			$sanitized_default_order_by = $default_order_by;
-		}
+                        'offset'       => 0,
+                        'order_by'     => 'fetched_at',
+                        'order'        => 'DESC',
+                ];
 
-		$args = wp_parse_args( $args, $defaults );
+                $args = wp_parse_args( $args, $defaults );
 
-		$where_clauses = [];
-		$where_values = [];
+                [ $order_by, $order_direction ] = self::sanitize_order_parameters(
+                        (string) $args['order_by'],
+                        (string) $args['order'],
+                        $defaults['order_by'],
+                        $defaults['order']
+                );
 
-		self::add_filter_clause( 'client_id', $args['client_id'], $where_clauses, $where_values, true );
-		self::add_filter_clause( 'source', $args['source'], $where_clauses, $where_values );
-		self::add_filter_clause( 'metric', $args['metric'], $where_clauses, $where_values );
+                $where_clauses = [];
+                $where_values = [];
 
-		if ( ! is_null( $args['period_start'] ) ) {
-			$where_clauses[] = 'period_start >= %s';
-			$where_values[] = $args['period_start'];
-		}
+                self::add_filter_clause( 'client_id', $args['client_id'], $where_clauses, $where_values, true );
+                self::add_filter_clause( 'source', $args['source'], $where_clauses, $where_values );
+                self::add_filter_clause( 'metric', $args['metric'], $where_clauses, $where_values );
 
-		if ( ! is_null( $args['period_end'] ) ) {
-			$where_clauses[] = 'period_end <= %s';
-			$where_values[] = $args['period_end'];
-		}
+                if ( ! is_null( $args['period_start'] ) ) {
+                        $where_clauses[] = 'period_start >= %s';
+                        $where_values[] = $args['period_start'];
+                }
 
-		$where_sql = ! empty( $where_clauses ) ? 'WHERE ' . implode( ' AND ', $where_clauses ) : '';
+                if ( ! is_null( $args['period_end'] ) ) {
+                        $where_clauses[] = 'period_end <= %s';
+                        $where_values[] = $args['period_end'];
+                }
 
-		$order_by_column = is_string( $args['order_by'] ) ? $args['order_by'] : $default_order_by;
-		if ( ! in_array( $order_by_column, $sortable_columns, true ) ) {
-			$order_by_column = $default_order_by;
-		}
+                $where_sql = ! empty( $where_clauses ) ? 'WHERE ' . implode( ' AND ', $where_clauses ) : '';
 
-		$order_by = sanitize_sql_orderby( $order_by_column );
-		if ( empty( $order_by ) || ! in_array( $order_by, $sortable_columns, true ) ) {
-			$order_by = $sanitized_default_order_by;
-		}
-		$order = in_array( strtoupper( $args['order'] ), [ 'ASC', 'DESC' ], true ) ? strtoupper( $args['order'] ) : 'DESC';
+                $limit  = max( 0, (int) $args['limit'] );
+                $offset = max( 0, (int) $args['offset'] );
 
-		$sql = "SELECT * FROM $table_name $where_sql ORDER BY $order_by $order LIMIT %d OFFSET %d";
+                $sql = sprintf(
+                        'SELECT * FROM %s %s ORDER BY %s %s LIMIT %%d OFFSET %%d',
+                        $table_name,
+                        $where_sql,
+                        $order_by,
+                        $order_direction
+                );
 
-		$where_values[] = (int) $args['limit'];
-		$where_values[] = (int) $args['offset'];
+                $where_values[] = $limit;
+                $where_values[] = $offset;
 
-		if ( ! empty( $where_values ) ) {
-			$prepared_sql = $wpdb->prepare( $sql, ...$where_values );
-		} else {
-			$prepared_sql = $sql;
-		}
+                $prepared_sql = $wpdb->prepare( $sql, ...$where_values );
 
-		$results = $wpdb->get_results( $prepared_sql );
+                $results = $wpdb->get_results( $prepared_sql );
 
-		// Decode JSON meta for each result
-		foreach ( $results as $result ) {
+                // Decode JSON meta for each result
+                foreach ( $results as $result ) {
 			if ( ! empty( $result->meta ) ) {
 				$result->meta = json_decode( $result->meta, true );
 			}
@@ -272,12 +281,12 @@ class MetricsCache {
 	 * @param array $args Query arguments
 	 * @return int Number of records
 	 */
-	public static function count( array $args = [] ): int {
-		global $wpdb;
+        public static function count( array $args = [] ): int {
+                global $wpdb;
 
-		$table_name = MetricsCacheTable::get_table_name();
+                $table_name = MetricsCacheTable::get_table_name();
 
-		$defaults = [
+                $defaults = [
 		        'client_id' => null,
 		        'source'    => null,
 		        'metric'    => null,
@@ -294,18 +303,18 @@ class MetricsCache {
 
 		$where_sql = ! empty( $where_clauses ) ? 'WHERE ' . implode( ' AND ', $where_clauses ) : '';
 
-		$sql = "SELECT COUNT(*) FROM $table_name $where_sql";
+                $sql = "SELECT COUNT(*) FROM $table_name $where_sql";
 
-		if ( ! empty( $where_values ) ) {
-		        $result = $wpdb->get_var( $wpdb->prepare( $sql, ...$where_values ) );
-		} else {
-		        $result = $wpdb->get_var( $sql );
-		}
+                if ( ! empty( $where_values ) ) {
+                        $result = $wpdb->get_var( $wpdb->prepare( $sql, ...$where_values ) );
+                } else {
+                        $result = $wpdb->get_var( $sql );
+                }
 
-		return (int) $result;
-	}
+                return (int) $result;
+        }
 
-	/**
+        /**
 	 * Add a sanitized filter clause to the WHERE portion of a query.
 	 *
 	 * @param string $column        Column name to filter.
@@ -314,17 +323,18 @@ class MetricsCache {
 	 * @param array  $where_values  Reference to the prepared value array.
 	 * @param bool   $is_numeric    Whether the column expects numeric values.
 	 */
-	private static function add_filter_clause( string $column, $value, array &$where_clauses, array &$where_values, bool $is_numeric = false ): void {
-		if ( is_null( $value ) ) {
-		        return;
-		}
+        private static function add_filter_clause( string $column, $value, array &$where_clauses, array &$where_values, bool $is_numeric = false ): void {
+                if ( is_null( $value ) ) {
+                        return;
+                }
 
-		$values = is_array( $value ) ? $value : [ $value ];
-		$sanitized_values = [];
+                $is_array_filter = is_array( $value );
+                $values          = $is_array_filter ? $value : [ $value ];
+                $sanitized_values = [];
 
-		foreach ( $values as $single_value ) {
-		        if ( is_null( $single_value ) ) {
-		                continue;
+                foreach ( $values as $single_value ) {
+                        if ( is_null( $single_value ) ) {
+                                continue;
 		        }
 
 		        $original_value = (string) $single_value;
@@ -350,17 +360,55 @@ class MetricsCache {
 		        return;
 		}
 
-		$placeholder = $is_numeric ? '%d' : '%s';
+                $placeholder = $is_numeric ? '%d' : '%s';
 
-		if ( count( $sanitized_values ) > 1 ) {
-		        $placeholders = implode( ', ', array_fill( 0, count( $sanitized_values ), $placeholder ) );
-		        $where_clauses[] = sprintf( '%s IN (%s)', $column, $placeholders );
-		} else {
-		        $where_clauses[] = sprintf( '%s = %s', $column, $placeholder );
-		}
+                if ( count( $sanitized_values ) > 1 || $is_array_filter ) {
+                        $placeholders = implode( ', ', array_fill( 0, count( $sanitized_values ), $placeholder ) );
+                        $where_clauses[] = sprintf( '%s IN (%s)', $column, $placeholders );
+                } else {
+                        $where_clauses[] = sprintf( '%s = %s', $column, $placeholder );
+                }
 
-		foreach ( $sanitized_values as $sanitized_value ) {
-		        $where_values[] = $sanitized_value;
-		}
-	}
+                foreach ( $sanitized_values as $sanitized_value ) {
+                        $where_values[] = $sanitized_value;
+                }
+        }
+
+        /**
+         * Sanitize ORDER BY parameters to ensure only whitelisted columns are used.
+         *
+         * @param string $order_by                Requested column.
+         * @param string $order_direction         Requested direction (ASC/DESC).
+         * @param string $default_order_by        Default column fallback.
+         * @param string $default_order_direction Default direction fallback.
+         *
+         * @return array{0:string,1:string}
+         */
+        private static function sanitize_order_parameters( string $order_by, string $order_direction, string $default_order_by, string $default_order_direction ): array {
+                $allowed_columns = self::ORDERABLE_COLUMNS;
+
+                $default_order_by = strtolower( $default_order_by );
+                if ( ! in_array( $default_order_by, $allowed_columns, true ) ) {
+                        $default_order_by = 'fetched_at';
+                }
+
+                $order_by = strtolower( trim( $order_by ) );
+                if ( ! in_array( $order_by, $allowed_columns, true ) ) {
+                        $order_by = $default_order_by;
+                }
+
+                $allowed_directions = [ 'ASC', 'DESC' ];
+
+                $default_order_direction = strtoupper( $default_order_direction );
+                if ( ! in_array( $default_order_direction, $allowed_directions, true ) ) {
+                        $default_order_direction = 'DESC';
+                }
+
+                $order_direction = strtoupper( trim( $order_direction ) );
+                if ( ! in_array( $order_direction, $allowed_directions, true ) ) {
+                        $order_direction = $default_order_direction;
+                }
+
+                return [ $order_by, $order_direction ];
+        }
 }

--- a/tests/MetricsAggregatorTest.php
+++ b/tests/MetricsAggregatorTest.php
@@ -301,7 +301,7 @@ class MetricsAggregatorTest extends TestCase {
                         MetricsSchema::KPI_CLS,
                 ];
 
-                $aggregated = MetricsAggregator::get_aggregated_metrics( $client_id, $period_start, $period_end, $kpis );
+                $aggregated = MetricsAggregator::get_metrics( $client_id, $period_start, $period_end, $kpis );
 
                 $this->assertEqualsWithDelta( 3.0, $aggregated[ MetricsSchema::KPI_AVG_POSITION ]['total_value'], 0.0001 );
                 $this->assertEquals( 2, $aggregated[ MetricsSchema::KPI_AVG_POSITION ]['count'] );

--- a/tests/MetricsCacheTest.php
+++ b/tests/MetricsCacheTest.php
@@ -10,247 +10,504 @@ use FP\DigitalMarketing\Models\MetricsCache;
 use FP\DigitalMarketing\Database\MetricsCacheTable;
 
 /**
- * Test case for MetricsCache CRUD operations
+ * Lightweight wpdb stub for MetricsCache tests.
+ */
+class MetricsCacheWPDBStub {
+        /**
+         * WordPress table prefix.
+         *
+         * @var string
+         */
+        public string $prefix = 'wp_';
+
+        /**
+         * Next insert ID to report.
+         *
+         * @var int
+         */
+        public int $next_insert_id = 1;
+
+        /**
+         * Last insert ID stored on successful insert.
+         *
+         * @var int
+         */
+        public int $insert_id = 0;
+
+        /**
+         * Whether insert operations should fail.
+         *
+         * @var bool
+         */
+        public bool $insert_should_fail = false;
+
+        /**
+         * Result to return for update operations.
+         *
+         * @var int
+         */
+        public int $update_result = 1;
+
+        /**
+         * Result to return for delete operations.
+         *
+         * @var int
+         */
+        public $delete_result = 1;
+
+        /**
+         * Row result for get_row queries.
+         *
+         * @var mixed
+         */
+        public $get_row_result = null;
+
+        /**
+         * Results returned from get_results.
+         *
+         * @var array
+         */
+        public array $results = [];
+
+        /**
+         * Value returned from get_var.
+         *
+         * @var mixed
+         */
+        public $var_result = null;
+
+        /**
+         * Last prepared query string.
+         *
+         * @var string
+         */
+        public string $prepared_query = '';
+
+        /**
+         * Arguments passed to the last prepare call.
+         *
+         * @var array
+         */
+        public array $prepare_args = [];
+
+        /**
+         * Last executed query string.
+         *
+         * @var string
+         */
+        public string $last_query = '';
+
+        /**
+         * Capture prepared queries and arguments.
+         *
+         * @param string $query SQL query.
+         * @param mixed  ...$args Query arguments.
+         * @return string
+         */
+        public function prepare( string $query, ...$args ): string {
+                $this->prepared_query = $query;
+                $this->prepare_args   = $args;
+
+                return $query;
+        }
+
+        /**
+         * Simulate wpdb::insert behaviour.
+         *
+         * @return int|false
+         */
+        public function insert( ...$args ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+                if ( $this->insert_should_fail ) {
+                        return false;
+                }
+
+                $this->insert_id = $this->next_insert_id++;
+
+                return 1;
+        }
+
+        /**
+         * Simulate wpdb::update behaviour.
+         *
+         * @return int
+         */
+        public function update( ...$args ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+                return $this->update_result;
+        }
+
+        /**
+         * Simulate wpdb::delete behaviour.
+         *
+         * @return int|false
+         */
+        public function delete( ...$args ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+                return $this->delete_result;
+        }
+
+        /**
+         * Provide row results.
+         *
+         * @param mixed $query SQL query.
+         * @return mixed
+         */
+        public function get_row( $query ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+                $this->last_query = is_string( $query ) ? $query : '';
+
+                return $this->get_row_result;
+        }
+
+        /**
+         * Provide result sets.
+         *
+         * @param mixed $query SQL query.
+         * @return array
+         */
+        public function get_results( $query ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+                $this->last_query = is_string( $query ) ? $query : '';
+
+                return $this->results;
+        }
+
+        /**
+         * Provide scalar results.
+         *
+         * @param mixed $query SQL query.
+         * @return mixed
+         */
+        public function get_var( $query ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+                $this->last_query = is_string( $query ) ? $query : '';
+
+                return $this->var_result;
+        }
+
+        /**
+         * Capture arbitrary queries.
+         *
+         * @param mixed $query SQL query.
+         * @return bool
+         */
+        public function query( $query ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+                $this->last_query = is_string( $query ) ? $query : '';
+
+                return true;
+        }
+
+        /**
+         * Provide charset information when required by table helpers.
+         *
+         * @return string
+         */
+        public function get_charset_collate(): string {
+                return 'utf8_general_ci';
+        }
+}
+
+/**
+ * Test case for MetricsCache CRUD operations.
  */
 class MetricsCacheTest extends TestCase {
 
-	/**
-	 * Mock WordPress database object
-	 *
-	 * @var object
-	 */
-	private $wpdb_mock;
+        /**
+         * Previous global wpdb instance.
+         *
+         * @var mixed
+         */
+        private $previous_wpdb;
 
-	/**
-	 * Set up test environment
-	 */
-	protected function setUp(): void {
-		parent::setUp();
-		
-		// Create mock wpdb object
-                $this->wpdb_mock = $this->createMock( stdClass::class );
-                $this->wpdb_mock->prefix = 'wp_';
-                $this->wpdb_mock->insert_id = 1;
-                $this->wpdb_mock->method( 'prepare' )->willReturnArgument( 0 );
-		
-		// Set global $wpdb for tests
-		global $wpdb;
-		$wpdb = $this->wpdb_mock;
-	}
+        /**
+         * Stubbed wpdb instance.
+         *
+         * @var MetricsCacheWPDBStub
+         */
+        private MetricsCacheWPDBStub $wpdb_stub;
 
-	/**
-	 * Test table name generation
-	 */
-	public function test_get_table_name(): void {
-		$expected = 'wp_fp_metrics_cache';
-		$actual = MetricsCacheTable::get_table_name();
-		
-		$this->assertEquals( $expected, $actual );
-	}
+        /**
+         * Set up test environment.
+         */
+        protected function setUp(): void {
+                parent::setUp();
 
-	/**
-	 * Test saving a metric record
-	 */
-	public function test_save_metric(): void {
-		// Mock successful insert
-		$this->wpdb_mock->method( 'insert' )->willReturn( 1 );
-		
-		$result = MetricsCache::save(
-			123,                           // client_id
-			'google_analytics_4',          // source
-			'sessions',                    // metric
-			'2024-01-01 00:00:00',        // period_start
-			'2024-01-31 23:59:59',        // period_end
-			'1500',                       // value
-			[ 'device' => 'desktop' ]     // meta
-		);
-		
-		$this->assertEquals( 1, $result );
-	}
+                global $wpdb;
 
-	/**
-	 * Test saving metric with minimal data
-	 */
-	public function test_save_metric_minimal(): void {
-		// Mock successful insert
-		$this->wpdb_mock->method( 'insert' )->willReturn( 1 );
-		
-		$result = MetricsCache::save(
-			456,                          // client_id
-			'facebook_ads',               // source
-			'impressions',                // metric
-			'2024-02-01 00:00:00',       // period_start
-			'2024-02-29 23:59:59',       // period_end
-			'25000'                      // value
-		);
-		
-		$this->assertEquals( 1, $result );
-	}
+                $this->previous_wpdb = $wpdb ?? null;
+                $this->wpdb_stub     = new MetricsCacheWPDBStub();
 
-	/**
-	 * Test saving metric failure
-	 */
-	public function test_save_metric_failure(): void {
-		// Mock failed insert
-		$this->wpdb_mock->method( 'insert' )->willReturn( false );
-		
-		$result = MetricsCache::save(
-			789,
-			'google_ads',
-			'clicks',
-			'2024-03-01 00:00:00',
-			'2024-03-31 23:59:59',
-			'850'
-		);
-		
-		$this->assertFalse( $result );
-	}
+                $wpdb = $this->wpdb_stub;
+        }
 
-	/**
-	 * Test getting a metric record by ID
-	 */
-	public function test_get_metric(): void {
-		// Mock successful get
-		$mock_result = (object) [
-			'id'           => 1,
-			'client_id'    => 123,
-			'source'       => 'google_analytics_4',
-			'metric'       => 'sessions',
-			'period_start' => '2024-01-01 00:00:00',
-			'period_end'   => '2024-01-31 23:59:59',
-			'value'        => '1500',
-			'meta'         => '{"device":"desktop"}',
-			'fetched_at'   => '2024-01-31 12:00:00',
-		];
-		
-		$this->wpdb_mock->method( 'get_row' )->willReturn( $mock_result );
-		$this->wpdb_mock->method( 'prepare' )->willReturn( 'SELECT * FROM wp_fp_metrics_cache WHERE id = 1' );
-		
-		$result = MetricsCache::get( 1 );
-		
-		$this->assertNotNull( $result );
-		$this->assertEquals( 1, $result->id );
-		$this->assertEquals( 'sessions', $result->metric );
-		$this->assertEquals( [ 'device' => 'desktop' ], $result->meta );
-	}
+        /**
+         * Restore original global state.
+         */
+        protected function tearDown(): void {
+                global $wpdb;
 
-	/**
-	 * Test getting non-existent metric record
-	 */
-	public function test_get_metric_not_found(): void {
-		// Mock empty result
-		$this->wpdb_mock->method( 'get_row' )->willReturn( null );
-		$this->wpdb_mock->method( 'prepare' )->willReturn( 'SELECT * FROM wp_fp_metrics_cache WHERE id = 999' );
-		
-		$result = MetricsCache::get( 999 );
-		
-		$this->assertNull( $result );
-	}
+                if ( null !== $this->previous_wpdb ) {
+                        $wpdb = $this->previous_wpdb;
+                } else {
+                        unset( $GLOBALS['wpdb'] );
+                }
 
-	/**
-	 * Test getting multiple metrics with filters
-	 */
-	public function test_get_metrics_with_filters(): void {
-		// Mock multiple results
-		$mock_results = [
-			(object) [
-				'id'           => 1,
-				'client_id'    => 123,
-				'source'       => 'google_analytics_4',
-				'metric'       => 'sessions',
-				'period_start' => '2024-01-01 00:00:00',
-				'period_end'   => '2024-01-31 23:59:59',
-				'value'        => '1500',
-				'meta'         => null,
-				'fetched_at'   => '2024-01-31 12:00:00',
-			],
-			(object) [
-				'id'           => 2,
-				'client_id'    => 123,
-				'source'       => 'google_analytics_4',
-				'metric'       => 'pageviews',
-				'period_start' => '2024-01-01 00:00:00',
-				'period_end'   => '2024-01-31 23:59:59',
-				'value'        => '4500',
-				'meta'         => null,
-				'fetched_at'   => '2024-01-31 12:00:00',
-			],
-		];
-		
-		$this->wpdb_mock->method( 'get_results' )->willReturn( $mock_results );
-		$this->wpdb_mock->method( 'prepare' )->willReturn( 'SELECT * FROM wp_fp_metrics_cache WHERE client_id = 123 ORDER BY fetched_at DESC LIMIT 100 OFFSET 0' );
-		
-		$result = MetricsCache::get_metrics( [ 'client_id' => 123 ] );
-		
-		$this->assertIsArray( $result );
-		$this->assertCount( 2, $result );
-		$this->assertEquals( 'sessions', $result[0]->metric );
-		$this->assertEquals( 'pageviews', $result[1]->metric );
-	}
+                parent::tearDown();
+        }
 
-	/**
-	 * Test updating a metric record
-	 */
-	public function test_update_metric(): void {
-		// Mock successful update
-		$this->wpdb_mock->method( 'update' )->willReturn( 1 );
-		
-		$result = MetricsCache::update( 1, [
-			'value' => '1800',
-			'meta'  => [ 'device' => 'mobile' ],
-		] );
-		
-		$this->assertTrue( $result );
-	}
+        /**
+         * Test table name generation.
+         */
+        public function test_get_table_name(): void {
+                $expected = 'wp_fp_metrics_cache';
+                $actual   = MetricsCacheTable::get_table_name();
 
-	/**
-	 * Test updating with invalid fields
-	 */
-	public function test_update_metric_invalid_fields(): void {
-		$result = MetricsCache::update( 1, [
-			'invalid_field' => 'test',
-		] );
-		
-		$this->assertFalse( $result );
-	}
+                $this->assertEquals( $expected, $actual );
+        }
 
-	/**
-	 * Test deleting a metric record
-	 */
-	public function test_delete_metric(): void {
-		// Mock successful delete
-		$this->wpdb_mock->method( 'delete' )->willReturn( 1 );
-		
-		$result = MetricsCache::delete( 1 );
-		
-		$this->assertTrue( $result );
-	}
+        /**
+         * Test saving a metric record.
+         */
+        public function test_save_metric(): void {
+                $result = MetricsCache::save(
+                        123,
+                        'google_analytics_4',
+                        'sessions',
+                        '2024-01-01 00:00:00',
+                        '2024-01-31 23:59:59',
+                        '1500',
+                        [ 'device' => 'desktop' ]
+                );
 
-	/**
-	 * Test deleting by criteria
-	 */
-	public function test_delete_by_criteria(): void {
-		// Mock successful bulk delete
-		$this->wpdb_mock->method( 'delete' )->willReturn( 3 );
-		
-		$result = MetricsCache::delete_by_criteria( [
-			'client_id' => 123,
-			'source'    => 'google_analytics_4',
-		] );
-		
-		$this->assertEquals( 3, $result );
-	}
+                $this->assertEquals( 1, $result );
+        }
 
-	/**
-	 * Test counting records
-	 */
-	public function test_count_metrics(): void {
-		// Mock count result
-		$this->wpdb_mock->method( 'get_var' )->willReturn( '5' );
-		$this->wpdb_mock->method( 'prepare' )->willReturn( 'SELECT COUNT(*) FROM wp_fp_metrics_cache WHERE client_id = 123' );
-		
-		$result = MetricsCache::count( [ 'client_id' => 123 ] );
-		
-		$this->assertEquals( 5, $result );
-	}
+        /**
+         * Test saving metric with minimal data.
+         */
+        public function test_save_metric_minimal(): void {
+                $result = MetricsCache::save(
+                        456,
+                        'facebook_ads',
+                        'impressions',
+                        '2024-02-01 00:00:00',
+                        '2024-02-29 23:59:59',
+                        '25000'
+                );
+
+                $this->assertEquals( 1, $result );
+        }
+
+        /**
+         * Test saving metric failure.
+         */
+        public function test_save_metric_failure(): void {
+                $this->wpdb_stub->insert_should_fail = true;
+
+                $result = MetricsCache::save(
+                        789,
+                        'google_ads',
+                        'clicks',
+                        '2024-03-01 00:00:00',
+                        '2024-03-31 23:59:59',
+                        '850'
+                );
+
+                $this->assertFalse( $result );
+        }
+
+        /**
+         * Test getting a metric record by ID.
+         */
+        public function test_get_metric(): void {
+                $this->wpdb_stub->get_row_result = (object) [
+                        'id'           => 1,
+                        'client_id'    => 123,
+                        'source'       => 'google_analytics_4',
+                        'metric'       => 'sessions',
+                        'period_start' => '2024-01-01 00:00:00',
+                        'period_end'   => '2024-01-31 23:59:59',
+                        'value'        => '1500',
+                        'meta'         => '{"device":"desktop"}',
+                        'fetched_at'   => '2024-01-31 12:00:00',
+                ];
+
+                $result = MetricsCache::get( 1 );
+
+                $this->assertNotNull( $result );
+                $this->assertEquals( 1, $result->id );
+                $this->assertEquals( [ 'device' => 'desktop' ], $result->meta );
+                $this->assertStringContainsString( 'WHERE id = %d', $this->wpdb_stub->prepared_query );
+        }
+
+        /**
+         * Test getting non-existent metric record.
+         */
+        public function test_get_metric_not_found(): void {
+                $this->wpdb_stub->get_row_result = null;
+
+                $result = MetricsCache::get( 999 );
+
+                $this->assertNull( $result );
+        }
+
+        /**
+         * Test getting multiple metrics with filters.
+         */
+        public function test_get_metrics_with_filters(): void {
+                $this->wpdb_stub->results = [
+                        (object) [
+                                'id'           => 1,
+                                'client_id'    => 123,
+                                'source'       => 'google_analytics_4',
+                                'metric'       => 'sessions',
+                                'period_start' => '2024-01-01 00:00:00',
+                                'period_end'   => '2024-01-31 23:59:59',
+                                'value'        => '1500',
+                                'meta'         => null,
+                                'fetched_at'   => '2024-01-31 12:00:00',
+                        ],
+                        (object) [
+                                'id'           => 2,
+                                'client_id'    => 123,
+                                'source'       => 'google_analytics_4',
+                                'metric'       => 'pageviews',
+                                'period_start' => '2024-01-01 00:00:00',
+                                'period_end'   => '2024-01-31 23:59:59',
+                                'value'        => '4500',
+                                'meta'         => null,
+                                'fetched_at'   => '2024-01-31 12:00:00',
+                        ],
+                ];
+
+                $result = MetricsCache::get_metrics( [ 'client_id' => 123 ] );
+
+                $this->assertIsArray( $result );
+                $this->assertCount( 2, $result );
+                $this->assertEquals( [ 123, 100, 0 ], $this->wpdb_stub->prepare_args );
+                $this->assertStringContainsString( 'WHERE client_id = %d', $this->wpdb_stub->prepared_query );
+        }
+
+        /**
+         * Ensure array filters generate IN clauses with proper placeholders.
+         */
+        public function test_get_metrics_with_array_filters_uses_in_clause(): void {
+                $this->wpdb_stub->results = [];
+
+                MetricsCache::get_metrics(
+                        [
+                                'client_id' => [ 10, 20 ],
+                                'source'    => [ 'google_analytics_4', 'facebook_ads' ],
+                                'metric'    => [ 'sessions', 'clicks' ],
+                        ]
+                );
+
+                $this->assertStringContainsString( 'client_id IN (%d, %d)', $this->wpdb_stub->prepared_query );
+                $this->assertStringContainsString( 'source IN (%s, %s)', $this->wpdb_stub->prepared_query );
+                $this->assertStringContainsString( 'metric IN (%s, %s)', $this->wpdb_stub->prepared_query );
+                $this->assertEquals(
+                        [
+                                10,
+                                20,
+                                'google_analytics_4',
+                                'facebook_ads',
+                                'sessions',
+                                'clicks',
+                                100,
+                                0,
+                        ],
+                        $this->wpdb_stub->prepare_args
+                );
+        }
+
+        /**
+         * Ensure invalid ordering falls back to safe defaults.
+         */
+        public function test_get_metrics_invalid_ordering_falls_back_to_default(): void {
+                $this->wpdb_stub->results = [];
+
+                MetricsCache::get_metrics(
+                        [
+                                'order_by' => '1=1; DROP TABLE',
+                                'order'    => 'sideways',
+                        ]
+                );
+
+                $this->assertStringContainsString( 'ORDER BY fetched_at DESC', $this->wpdb_stub->prepared_query );
+        }
+
+        /**
+         * Test updating a metric record.
+         */
+        public function test_update_metric(): void {
+                $this->wpdb_stub->update_result = 1;
+
+                $result = MetricsCache::update( 1, [
+                        'value' => '1800',
+                        'meta'  => [ 'device' => 'mobile' ],
+                ] );
+
+                $this->assertTrue( $result );
+        }
+
+        /**
+         * Test updating with invalid fields.
+         */
+        public function test_update_metric_invalid_fields(): void {
+                $result = MetricsCache::update( 1, [ 'invalid_field' => 'test' ] );
+
+                $this->assertFalse( $result );
+        }
+
+        /**
+         * Test deleting a metric record.
+         */
+        public function test_delete_metric(): void {
+                $this->wpdb_stub->delete_result = 1;
+
+                $result = MetricsCache::delete( 1 );
+
+                $this->assertTrue( $result );
+        }
+
+        /**
+         * Test deleting by criteria.
+         */
+        public function test_delete_by_criteria(): void {
+                $this->wpdb_stub->delete_result = 3;
+
+                $result = MetricsCache::delete_by_criteria(
+                        [
+                                'client_id' => 123,
+                                'source'    => 'google_analytics_4',
+                        ]
+                );
+
+                $this->assertEquals( 3, $result );
+        }
+
+        /**
+         * Test counting records with simple filters.
+         */
+        public function test_count_metrics(): void {
+                $this->wpdb_stub->var_result = '5';
+
+                $result = MetricsCache::count( [ 'client_id' => 123 ] );
+
+                $this->assertEquals( 5, $result );
+                $this->assertStringContainsString( 'client_id = %d', $this->wpdb_stub->prepared_query );
+        }
+
+        /**
+         * Ensure count queries use IN clauses for array filters.
+         */
+        public function test_count_with_array_filters_uses_in_clause(): void {
+                $this->wpdb_stub->var_result = '3';
+
+                $result = MetricsCache::count(
+                        [
+                                'source' => [ 'google_analytics_4', 'facebook_ads' ],
+                                'metric' => [ 'sessions', 'clicks' ],
+                        ]
+                );
+
+                $this->assertEquals( 3, $result );
+                $this->assertStringContainsString( 'source IN (%s, %s)', $this->wpdb_stub->prepared_query );
+                $this->assertStringContainsString( 'metric IN (%s, %s)', $this->wpdb_stub->prepared_query );
+        }
 }


### PR DESCRIPTION
## Summary
- Harden MetricsCache queries by whitelisting order-by columns, supporting array filters with IN clauses, and sanitising limit/offset handling.
- Update MetricsAggregator to compute average and percentile aggregations after normalising values so Core Web Vitals and search metrics aggregate correctly.
- Clamp custom reports table pagination parameters and expand PHPUnit coverage for MetricsCache array filters and aggregator results.

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml --filter MetricsCacheTest`
- `./vendor/bin/phpunit --configuration phpunit.xml --filter MetricsAggregatorTest`


------
https://chatgpt.com/codex/tasks/task_e_68d3c3fc3c88832f93072eff82876dbf