### PR TITLE
Improve conversions export and segmentation safeguards

### DIFF
--- a/src/Admin/ConversionEventsAdmin.php
+++ b/src/Admin/ConversionEventsAdmin.php
@@ -16,6 +16,7 @@ use FP\DigitalMarketing\Database\ConversionEventsTable;
 use FP\DigitalMarketing\Helpers\Capabilities;
 use FP\DigitalMarketing\Admin\MenuManager;
 use FP\DigitalMarketing\Tools\Exports\CsvExporter;
+use FP\DigitalMarketing\Tools\Exports\ConversionsExporter;
 
 /**
  * Conversion Events Admin class
@@ -873,49 +874,11 @@ class ConversionEventsAdmin {
 
 		fwrite( $handle, "\xEF\xBB\xBF" );
 
-		$headers = [
-			__( 'ID', 'fp-digital-marketing' ),
-			__( 'ID Evento', 'fp-digital-marketing' ),
-			__( 'Nome Evento', 'fp-digital-marketing' ),
-			__( 'Tipo', 'fp-digital-marketing' ),
-			__( 'Cliente ID', 'fp-digital-marketing' ),
-			__( 'Sorgente', 'fp-digital-marketing' ),
-			__( 'ID Evento Sorgente', 'fp-digital-marketing' ),
-			__( 'Valore Evento', 'fp-digital-marketing' ),
-			__( 'Valuta', 'fp-digital-marketing' ),
-			__( 'Duplicato', 'fp-digital-marketing' ),
-			__( 'Data Creazione', 'fp-digital-marketing' ),
-			__( 'Data Elaborazione', 'fp-digital-marketing' ),
-		];
+                CsvExporter::write_row( $handle, ConversionsExporter::get_headers() );
 
-		CsvExporter::write_row( $handle, $headers );
-
-		foreach ( $events as $event ) {
-			$is_duplicate = '';
-
-			if ( isset( $event['is_duplicate'] ) ) {
-				$is_duplicate = ( (int) $event['is_duplicate'] ) === 1
-					? __( 'Sì', 'fp-digital-marketing' )
-					: __( 'No', 'fp-digital-marketing' );
-			}
-
-			$row = [
-				$event['id'] ?? '',
-				$event['event_id'] ?? '',
-				$event['event_name'] ?? '',
-				$event['event_type'] ?? '',
-				$event['client_id'] ?? '',
-				$event['source'] ?? '',
-				$event['source_event_id'] ?? '',
-				$event['event_value'] ?? '',
-				$event['currency'] ?? '',
-				$is_duplicate,
-				$event['created_at'] ?? '',
-				$event['processed_at'] ?? '',
-			];
-
-			CsvExporter::write_row( $handle, $row );
-		}
+                foreach ( ConversionsExporter::build_rows( $events ) as $row ) {
+                        CsvExporter::write_row( $handle, $row );
+                }
 
 		rewind( $handle );
 		$content = stream_get_contents( $handle );

--- a/src/Database/ConversionEventsTable.php
+++ b/src/Database/ConversionEventsTable.php
@@ -291,17 +291,26 @@ class ConversionEventsTable {
 			$sql = $wpdb->prepare( $sql, $where_values );
 		}
 
-		$results = $wpdb->get_results( $sql, ARRAY_A );
+                $results = $wpdb->get_results( $sql, ARRAY_A );
 
-		// Unserialize attributes
-		foreach ( $results as &$result ) {
-			if ( ! empty( $result['event_attributes'] ) ) {
-				$result['event_attributes'] = json_decode( $result['event_attributes'], true );
-			}
-		}
+                if ( ! is_array( $results ) || empty( $results ) ) {
+                        return [];
+                }
 
-		return $results;
-	}
+                // Unserialize attributes
+                foreach ( $results as &$result ) {
+                        if ( ! empty( $result['event_attributes'] ) ) {
+                                $decoded_attributes = json_decode( $result['event_attributes'], true );
+
+                                if ( is_array( $decoded_attributes ) ) {
+                                        $result['event_attributes'] = $decoded_attributes;
+                                }
+                        }
+                }
+                unset( $result );
+
+                return $results;
+        }
 
 	/**
 	 * Get event count with filtering

--- a/src/Helpers/SegmentationEngine.php
+++ b/src/Helpers/SegmentationEngine.php
@@ -13,7 +13,7 @@ use FP\DigitalMarketing\Models\AudienceSegment;
 use FP\DigitalMarketing\Models\ConversionEvent;
 use FP\DigitalMarketing\Database\AudienceSegmentTable;
 use FP\DigitalMarketing\Database\ConversionEventsTable;
-use DateTime;
+use DateTimeInterface;
 use Exception;
 
 /**
@@ -120,20 +120,32 @@ class SegmentationEngine {
 			// Clear existing membership for fresh evaluation
 			AudienceSegmentTable::clear_segment_membership( $segment->get_id() );
 
-			// Get all unique users for this client
-			$users = self::get_unique_users_for_client( $segment->get_client_id() );
+                        // Get all unique users for this client
+                        $users = self::get_unique_users_for_client( $segment->get_client_id() );
 
-			foreach ( $users as $user_id ) {
-				if ( self::evaluate_user_against_segment( $user_id, $segment ) ) {
-					AudienceSegmentTable::add_user_to_segment( 
-						$segment->get_id(), 
-						$user_id, 
-						$segment->get_client_id() 
-					);
-					$results['member_count']++;
-					$results['new_members']++;
-				}
-			}
+                        $user_events_index = ! empty( $users )
+                                ? self::get_user_events_index( $segment->get_client_id(), $users )
+                                : [];
+
+                        foreach ( $users as $user_id ) {
+                                $user_id = is_scalar( $user_id ) ? (string) $user_id : '';
+
+                                if ( '' === $user_id ) {
+                                        continue;
+                                }
+
+                                $user_events = $user_events_index[ $user_id ] ?? [];
+
+                                if ( self::evaluate_user_against_segment( $user_id, $segment, $user_events ) ) {
+                                        AudienceSegmentTable::add_user_to_segment(
+                                                $segment->get_id(),
+                                                $user_id,
+                                                $segment->get_client_id()
+                                        );
+                                        $results['member_count']++;
+                                        $results['new_members']++;
+                                }
+                        }
 
 			// Update segment cache
 			AudienceSegmentTable::update_member_count_cache( $segment->get_id() );
@@ -145,50 +157,61 @@ class SegmentationEngine {
 		return $results;
 	}
 
-	/**
-	 * Evaluate a specific user against a segment
-	 *
-	 * @param string          $user_id The user ID to evaluate
-	 * @param AudienceSegment $segment The segment to evaluate against
-	 * @return bool True if user matches segment criteria
-	 */
-	public static function evaluate_user_against_segment( string $user_id, AudienceSegment $segment ): bool {
-		if ( ! $user_id || ! $segment->is_active() ) {
-			return false;
-		}
+        /**
+         * Evaluate a specific user against a segment
+         *
+         * @param string          $user_id      The user ID to evaluate
+         * @param AudienceSegment $segment      The segment to evaluate against
+         * @param array|null      $user_events  Optional pre-fetched user events
+         * @return bool True if user matches segment criteria
+         */
+        public static function evaluate_user_against_segment( string $user_id, AudienceSegment $segment, ?array $user_events = null ): bool {
+                $user_id = trim( $user_id );
 
-		$rules = $segment->get_rules();
-		if ( empty( $rules ) ) {
-			return false;
-		}
+                if ( '' === $user_id || ! $segment->is_active() ) {
+                        return false;
+                }
 
-		// Get user's conversion events
-		$user_events = ConversionEventsTable::get_events( [
-			'client_id' => $segment->get_client_id(),
-			'user_id' => $user_id,
-			'exclude_duplicates' => true,
-		], 1000, 0 );
+                $rules = $segment->get_rules();
+                if ( empty( $rules ) ) {
+                        return false;
+                }
 
-		// Default to AND logic between rules (all must match)
-		$logic = $rules['logic'] ?? 'AND';
-		$rule_conditions = $rules['conditions'] ?? [];
+                $rule_conditions = isset( $rules['conditions'] ) && is_array( $rules['conditions'] )
+                        ? $rules['conditions']
+                        : [];
 
-		if ( empty( $rule_conditions ) ) {
-			return false;
-		}
+                if ( empty( $rule_conditions ) ) {
+                        return false;
+                }
 
-		$matches = [];
-		foreach ( $rule_conditions as $condition ) {
-			$matches[] = self::evaluate_condition( $condition, $user_events, $user_id );
-		}
+                if ( null === $user_events ) {
+                        $user_events = ConversionEventsTable::get_events( [
+                                'client_id' => $segment->get_client_id(),
+                                'user_id' => $user_id,
+                                'exclude_duplicates' => true,
+                        ], 1000, 0 );
+                }
 
-		// Apply logic
-		if ( $logic === 'OR' ) {
-			return in_array( true, $matches, true );
-		} else {
-			return ! in_array( false, $matches, true );
-		}
-	}
+                if ( ! is_array( $user_events ) ) {
+                        $user_events = [];
+                }
+
+                // Default to AND logic between rules (all must match)
+                $logic = strtoupper( $rules['logic'] ?? 'AND' );
+
+                $matches = [];
+                foreach ( $rule_conditions as $condition ) {
+                        $matches[] = self::evaluate_condition( $condition, $user_events, $user_id );
+                }
+
+                // Apply logic
+                if ( 'OR' === $logic ) {
+                        return in_array( true, $matches, true );
+                } else {
+                        return ! in_array( false, $matches, true );
+                }
+        }
 
 	/**
 	 * Evaluate a single condition against user data
@@ -240,9 +263,14 @@ class SegmentationEngine {
 		$operator = $condition['operator'] ?? '';
 		$value = $condition['value'] ?? '';
 
-		$matching_events = array_filter( $user_events, function( $event ) use ( $event_type ) {
-			return $event['event_type'] === $event_type;
-		} );
+                $matching_events = array_filter(
+                        $user_events,
+                        static function ( $event ) use ( $event_type ) {
+                                return is_array( $event )
+                                        && isset( $event['event_type'] )
+                                        && $event['event_type'] === $event_type;
+                        }
+                );
 
 		$count = count( $matching_events );
 
@@ -274,13 +302,17 @@ class SegmentationEngine {
 		$operator = $condition['operator'] ?? '';
 		$value = $condition['value'] ?? '';
 
-		foreach ( $user_events as $event ) {
-			$event_value = $event[ $utm_field ] ?? '';
-			
-			if ( self::compare_values( $event_value, $value, $operator ) ) {
-				return true;
-			}
-		}
+                foreach ( $user_events as $event ) {
+                        if ( ! is_array( $event ) ) {
+                                continue;
+                        }
+
+                        $event_value = $event[ $utm_field ] ?? '';
+
+                        if ( self::compare_values( $event_value, $value, $operator ) ) {
+                                return true;
+                        }
+                }
 
 		return false;
 	}
@@ -296,12 +328,16 @@ class SegmentationEngine {
 		$operator = $condition['operator'] ?? '';
 		$value = $condition['value'] ?? ''; // mobile, desktop, tablet
 
-		foreach ( $user_events as $event ) {
-			$user_agent = $event['user_agent'] ?? '';
-			$device_type = self::detect_device_type( $user_agent );
-			
-			if ( self::compare_values( $device_type, $value, $operator ) ) {
-				return true;
+                foreach ( $user_events as $event ) {
+                        if ( ! is_array( $event ) ) {
+                                continue;
+                        }
+
+                        $user_agent = $event['user_agent'] ?? '';
+                        $device_type = self::detect_device_type( $user_agent );
+
+                        if ( self::compare_values( $device_type, $value, $operator ) ) {
+                                return true;
 			}
 		}
 
@@ -319,12 +355,16 @@ class SegmentationEngine {
 		$operator = $condition['operator'] ?? '';
 		$value = $condition['value'] ?? ''; // country code or region
 
-		foreach ( $user_events as $event ) {
-			$ip_address = $event['ip_address'] ?? '';
-			$country = self::get_country_from_ip( $ip_address );
-			
-			if ( self::compare_values( $country, $value, $operator ) ) {
-				return true;
+                foreach ( $user_events as $event ) {
+                        if ( ! is_array( $event ) ) {
+                                continue;
+                        }
+
+                        $ip_address = $event['ip_address'] ?? '';
+                        $country = self::get_country_from_ip( $ip_address );
+
+                        if ( self::compare_values( $country, $value, $operator ) ) {
+                                return true;
 			}
 		}
 
@@ -345,47 +385,77 @@ class SegmentationEngine {
 
                 switch ( $behavior_type ) {
                         case 'visit_frequency':
-                                $session_ids = array_filter(
-                                        array_column( $user_events, 'session_id' ),
-                                        static function ( $session_id ) {
-                                                return null !== $session_id && '' !== $session_id;
+                                $session_ids = [];
+
+                                foreach ( $user_events as $event ) {
+                                        if ( ! is_array( $event ) ) {
+                                                continue;
                                         }
-                                );
+
+                                        $session_id = $event['session_id'] ?? null;
+
+                                        if ( null === $session_id || '' === $session_id ) {
+                                                continue;
+                                        }
+
+                                        $session_id = is_scalar( $session_id ) ? trim( (string) $session_id ) : '';
+
+                                        if ( '' === $session_id ) {
+                                                continue;
+                                        }
+
+                                        $session_ids[] = $session_id;
+                                }
 
                                 if ( empty( $session_ids ) ) {
                                         return false;
                                 }
 
                                 $unique_sessions = count( array_unique( $session_ids ) );
-                                return self::compare_numeric_values( $unique_sessions, floatval( $value ), $operator );
+                                return self::compare_numeric_values( $unique_sessions, (float) $value, $operator );
 
                         case 'total_events':
-                                if ( empty( $user_events ) ) {
-                                        return false;
-                                }
-
-                                $total_events = count( $user_events );
-                                return self::compare_numeric_values( $total_events, floatval( $value ), $operator );
-
-                        case 'recency':
-                                $event_dates = array_filter(
-                                        array_column( $user_events, 'created_at' ),
-                                        static function ( $event_date ) {
-                                                return null !== $event_date && '' !== $event_date;
+                                $valid_events = array_filter(
+                                        $user_events,
+                                        static function ( $event ): bool {
+                                                return is_array( $event );
                                         }
                                 );
 
-                                if ( empty( $event_dates ) ) {
+                                if ( empty( $valid_events ) ) {
                                         return false;
                                 }
 
-                                $latest_event = max( $event_dates );
+                                return self::compare_numeric_values( count( $valid_events ), (float) $value, $operator );
+
+                        case 'recency':
+                                $timestamps = [];
+
+                                foreach ( $user_events as $event ) {
+                                        if ( ! is_array( $event ) ) {
+                                                continue;
+                                        }
+
+                                        $timestamp = self::to_timestamp( $event['created_at'] ?? null );
+
+                                        if ( null === $timestamp ) {
+                                                continue;
+                                        }
+
+                                        $timestamps[] = $timestamp;
+                                }
+
+                                if ( empty( $timestamps ) ) {
+                                        return false;
+                                }
+
+                                $latest_event = max( $timestamps );
                                 $days_since = self::days_since_date( $latest_event );
-                                return self::compare_numeric_values( $days_since, floatval( $value ), $operator );
+                                return self::compare_numeric_values( $days_since, (float) $value, $operator );
 
                         default:
-				return false;
-		}
+                                return false;
+                }
 	}
 
 	/**
@@ -399,10 +469,20 @@ class SegmentationEngine {
 		$operator = $condition['operator'] ?? '';
 		$value = floatval( $condition['value'] ?? 0 );
 
-		$total_value = array_sum( array_column( $user_events, 'event_value' ) );
+                $total_value = 0.0;
 
-		return self::compare_numeric_values( $total_value, $value, $operator );
-	}
+                foreach ( $user_events as $event ) {
+                        if ( ! is_array( $event ) || ! isset( $event['event_value'] ) ) {
+                                continue;
+                        }
+
+                        if ( is_numeric( $event['event_value'] ) ) {
+                                $total_value += (float) $event['event_value'];
+                        }
+                }
+
+                return self::compare_numeric_values( $total_value, (float) $value, $operator );
+        }
 
 	/**
 	 * Compare two values using an operator
@@ -482,16 +562,27 @@ class SegmentationEngine {
 	 * @return bool True if any events in timeframe
 	 */
 	private static function has_events_in_last_days( array $events, int $days ): bool {
-		$cutoff_date = date( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+                if ( $days <= 0 ) {
+                        return false;
+                }
 
-		foreach ( $events as $event ) {
-			if ( $event['created_at'] >= $cutoff_date ) {
-				return true;
-			}
-		}
+                $seconds_per_day = defined( 'DAY_IN_SECONDS' ) ? (int) DAY_IN_SECONDS : 86400;
+                $cutoff_timestamp = time() - ( $days * $seconds_per_day );
 
-		return false;
-	}
+                foreach ( $events as $event ) {
+                        if ( ! is_array( $event ) ) {
+                                continue;
+                        }
+
+                        $timestamp = self::to_timestamp( $event['created_at'] ?? null );
+
+                        if ( null !== $timestamp && $timestamp >= $cutoff_timestamp ) {
+                                return true;
+                        }
+                }
+
+                return false;
+        }
 
 	/**
 	 * Detect device type from user agent
@@ -598,13 +689,110 @@ class SegmentationEngine {
 	 * @param string $date Date string
 	 * @return int Days since date
 	 */
-	private static function days_since_date( string $date ): int {
-		$date_obj = new DateTime( $date );
-		$now = new DateTime();
-		$diff = $now->diff( $date_obj );
+        private static function days_since_date( $date ): int {
+                $timestamp = self::to_timestamp( $date );
 
-		return $diff->days;
-	}
+                if ( null === $timestamp ) {
+                        return PHP_INT_MAX;
+                }
+
+                $now = time();
+
+                if ( $timestamp > $now ) {
+                        return 0;
+                }
+
+                $seconds_per_day = defined( 'DAY_IN_SECONDS' ) ? (int) DAY_IN_SECONDS : 86400;
+
+                return (int) floor( ( $now - $timestamp ) / $seconds_per_day );
+        }
+
+        /**
+         * Convert a datetime-like value to a Unix timestamp.
+         *
+         * @param mixed $value Value to convert.
+         * @return int|null Timestamp on success, null otherwise.
+         */
+        private static function to_timestamp( $value ): ?int {
+                if ( $value instanceof DateTimeInterface ) {
+                        return $value->getTimestamp();
+                }
+
+                if ( is_int( $value ) ) {
+                        return $value >= 0 ? $value : null;
+                }
+
+                if ( is_float( $value ) ) {
+                        $value = (int) $value;
+                        return $value >= 0 ? $value : null;
+                }
+
+                if ( is_string( $value ) ) {
+                        $trimmed = trim( $value );
+
+                        if ( '' === $trimmed ) {
+                                return null;
+                        }
+
+                        if ( ctype_digit( $trimmed ) ) {
+                                return (int) $trimmed;
+                        }
+
+                        $timestamp = strtotime( $trimmed );
+
+                        return false === $timestamp ? null : $timestamp;
+                }
+
+                return null;
+        }
+
+        /**
+         * Build an index of events keyed by user ID for faster lookups.
+         *
+         * @param int   $client_id Client identifier.
+         * @param array $user_ids  User identifiers to include.
+         * @return array<string, array<int, array>> Events grouped by user ID.
+         */
+        private static function get_user_events_index( int $client_id, array $user_ids ): array {
+                if ( empty( $user_ids ) ) {
+                        return [];
+                }
+
+                $limit = count( $user_ids ) * 25;
+                $limit = max( 1000, min( 20000, $limit ) );
+
+                $events = ConversionEventsTable::get_events(
+                        [
+                                'client_id' => $client_id,
+                                'user_id' => $user_ids,
+                                'exclude_duplicates' => true,
+                        ],
+                        $limit,
+                        0
+                );
+
+                if ( ! is_array( $events ) || empty( $events ) ) {
+                        return [];
+                }
+
+                $grouped = [];
+
+                foreach ( $events as $event ) {
+                        if ( ! is_array( $event ) ) {
+                                continue;
+                        }
+
+                        $user_id = isset( $event['user_id'] ) ? (string) $event['user_id'] : '';
+
+                        if ( '' === $user_id ) {
+                                continue;
+                        }
+
+                        $grouped[ $user_id ][] = $event;
+                }
+
+                return $grouped;
+        }
 
 	/**
 	 * Get unique users for a client
@@ -612,19 +800,42 @@ class SegmentationEngine {
 	 * @param int $client_id Client ID
 	 * @return array Array of unique user IDs
 	 */
-       public static function get_unique_users_for_client( int $client_id ): array {
-		global $wpdb;
+        public static function get_unique_users_for_client( int $client_id ): array {
+                global $wpdb;
 
-		$table_name = ConversionEventsTable::get_table_name();
-		$sql = $wpdb->prepare(
-			"SELECT DISTINCT user_id FROM $table_name WHERE client_id = %d AND user_id IS NOT NULL AND user_id != ''",
-			$client_id
-		);
+                $table_name = ConversionEventsTable::get_table_name();
+                $sql = $wpdb->prepare(
+                        "SELECT DISTINCT user_id FROM $table_name WHERE client_id = %d AND user_id IS NOT NULL AND user_id != ''",
+                        $client_id
+                );
 
-		$results = $wpdb->get_col( $sql );
+                $results = $wpdb->get_col( $sql );
 
-		return array_filter( $results );
-	}
+                if ( ! is_array( $results ) || empty( $results ) ) {
+                        return [];
+                }
+
+                $sanitized = array_filter(
+                        array_map(
+                                static function ( $user_id ) {
+                                        if ( is_scalar( $user_id ) ) {
+                                                $user_id = trim( (string) $user_id );
+
+                                                if ( function_exists( 'sanitize_text_field' ) ) {
+                                                        $user_id = sanitize_text_field( $user_id );
+                                                }
+                                        } else {
+                                                $user_id = '';
+                                        }
+
+                                        return '' !== $user_id ? $user_id : null;
+                                },
+                                $results
+                        )
+                );
+
+                return array_values( array_unique( $sanitized ) );
+        }
 
 	/**
 	 * Get available rule types

--- a/src/Models/ConversionEvent.php
+++ b/src/Models/ConversionEvent.php
@@ -566,13 +566,25 @@ class ConversionEvent {
                 $query = "SELECT
                         id,
                         event_id,
-                        event_name,
                         event_type,
+                        event_name,
                         client_id,
                         source,
                         source_event_id,
+                        user_id,
+                        session_id,
+                        utm_source,
+                        utm_medium,
+                        utm_campaign,
+                        utm_term,
+                        utm_content,
                         event_value,
                         currency,
+                        event_attributes,
+                        page_url,
+                        referrer_url,
+                        ip_address,
+                        user_agent,
                         is_duplicate,
                         created_at,
                         processed_at
@@ -587,12 +599,24 @@ class ConversionEvent {
 
                 $results = $wpdb->get_results( $query, ARRAY_A );
 
-                if ( empty( $results ) ) {
+                if ( ! is_array( $results ) || empty( $results ) ) {
                         return [];
                 }
 
                 return array_map(
                         static function ( array $event ): array {
+                                if ( isset( $event['event_attributes'] ) && is_array( $event['event_attributes'] ) ) {
+                                        return $event;
+                                }
+
+                                if ( isset( $event['event_attributes'] ) && is_string( $event['event_attributes'] ) && '' !== $event['event_attributes'] ) {
+                                        $decoded = json_decode( $event['event_attributes'], true );
+
+                                        if ( is_array( $decoded ) ) {
+                                                $event['event_attributes'] = $decoded;
+                                        }
+                                }
+
                                 $event['is_duplicate'] = isset( $event['is_duplicate'] ) ? (int) $event['is_duplicate'] : 0;
 
                                 return $event;

--- a/src/Tools/Exports/ConversionsExporter.php
+++ b/src/Tools/Exports/ConversionsExporter.php
@@ -1,0 +1,302 @@
+<?php
+/**
+ * Conversions export helpers.
+ *
+ * @package FP_Digital_Marketing_Suite
+ */
+
+declare(strict_types=1);
+
+namespace FP\DigitalMarketing\Tools\Exports;
+
+use DateTimeInterface;
+
+/**
+ * Utility helpers for building sanitized conversion exports.
+ */
+class ConversionsExporter {
+
+        /**
+         * Columns included in the conversion export.
+         */
+        private const EXPORT_COLUMNS = [
+                'id',
+                'event_id',
+                'event_type',
+                'event_name',
+                'client_id',
+                'source',
+                'source_event_id',
+                'user_id',
+                'session_id',
+                'utm_source',
+                'utm_medium',
+                'utm_campaign',
+                'utm_term',
+                'utm_content',
+                'event_value',
+                'currency',
+                'event_attributes',
+                'page_url',
+                'referrer_url',
+                'ip_address',
+                'user_agent',
+                'is_duplicate',
+                'created_at',
+                'processed_at',
+        ];
+
+        /**
+         * Retrieve export headers.
+         *
+         * @return array<string> Header labels matching table column names.
+         */
+        public static function get_headers(): array {
+                return self::EXPORT_COLUMNS;
+        }
+
+        /**
+         * Build a sanitized export row from raw event data.
+         *
+         * @param array $event Event data as retrieved from the repository.
+         * @return array<string> Row values aligned with {@see self::EXPORT_COLUMNS}.
+         */
+        public static function build_row( array $event ): array {
+                $row = [];
+
+                foreach ( self::EXPORT_COLUMNS as $column ) {
+                        $row[] = self::prepare_value( $column, $event[ $column ] ?? null );
+                }
+
+                return $row;
+        }
+
+        /**
+         * Build multiple export rows at once.
+         *
+         * @param array $events Raw events.
+         * @return array<int, array<string>> Prepared rows.
+         */
+        public static function build_rows( array $events ): array {
+                $rows = [];
+
+                foreach ( $events as $event ) {
+                        if ( ! is_array( $event ) ) {
+                                continue;
+                        }
+
+                        $rows[] = self::build_row( $event );
+                }
+
+                return $rows;
+        }
+
+        /**
+         * Prepare individual cell values depending on the column.
+         *
+         * @param string     $column Column name.
+         * @param mixed|null $value  Raw value.
+         * @return string Sanitized string representation.
+         */
+        private static function prepare_value( string $column, $value ): string {
+                switch ( $column ) {
+                        case 'event_attributes':
+                                return self::normalize_attributes( $value );
+
+                        case 'created_at':
+                        case 'processed_at':
+                                return self::normalize_datetime( $value );
+
+                        case 'event_value':
+                                return self::normalize_number( $value );
+
+                        case 'is_duplicate':
+                                return (string) ( (int) (bool) $value );
+
+                        case 'source_event_id':
+                                return self::normalize_source_event_id( $value );
+
+                        default:
+                                return self::cast_to_string( $value );
+                }
+        }
+
+        /**
+         * Normalize event attribute payloads.
+         *
+         * @param mixed $value Raw attributes value.
+         * @return string JSON-encoded representation or empty string.
+         */
+        private static function normalize_attributes( $value ): string {
+                if ( null === $value || '' === $value ) {
+                        return '';
+                }
+
+                if ( is_string( $value ) ) {
+                        return $value;
+                }
+
+                if ( is_array( $value ) || is_object( $value ) ) {
+                        $encoder = function_exists( 'wp_json_encode' ) ? 'wp_json_encode' : 'json_encode';
+                        $encoded = $encoder( $value );
+
+                        return is_string( $encoded ) ? $encoded : '';
+                }
+
+                return self::cast_to_string( $value );
+        }
+
+        /**
+         * Normalize datetime values to the MySQL format.
+         *
+         * @param mixed $value Raw datetime value.
+         * @return string Normalized datetime or empty string.
+         */
+        private static function normalize_datetime( $value ): string {
+                if ( $value instanceof DateTimeInterface ) {
+                        return $value->format( 'Y-m-d H:i:s' );
+                }
+
+                if ( is_int( $value ) ) {
+                        return $value > 0 ? gmdate( 'Y-m-d H:i:s', $value ) : '';
+                }
+
+                if ( is_string( $value ) ) {
+                        $trimmed = trim( $value );
+                        if ( '' === $trimmed ) {
+                                return '';
+                        }
+
+                        if ( preg_match( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $trimmed ) ) {
+                                return $trimmed;
+                        }
+
+                        if ( ctype_digit( $trimmed ) ) {
+                                $timestamp = (int) $trimmed;
+                                return $timestamp > 0 ? gmdate( 'Y-m-d H:i:s', $timestamp ) : '';
+                        }
+
+                        $timestamp = strtotime( $trimmed );
+                        if ( false !== $timestamp ) {
+                                return gmdate( 'Y-m-d H:i:s', $timestamp );
+                        }
+
+                        return '';
+                }
+
+                if ( is_numeric( $value ) ) {
+                        $timestamp = (int) $value;
+                        return $timestamp > 0 ? gmdate( 'Y-m-d H:i:s', $timestamp ) : '';
+                }
+
+                return '';
+        }
+
+        /**
+         * Normalize numeric values.
+         *
+         * @param mixed $value Raw numeric value.
+         * @return string Numeric string.
+         */
+        private static function normalize_number( $value ): string {
+                if ( is_numeric( $value ) ) {
+                        return (string) (float) $value;
+                }
+
+                return '0';
+        }
+
+        /**
+         * Ensure the source event identifier does not contain duplicates.
+         *
+         * @param mixed $value Raw identifier value.
+         * @return string De-duplicated identifier.
+         */
+        private static function normalize_source_event_id( $value ): string {
+                if ( null === $value ) {
+                        return '';
+                }
+
+                if ( is_array( $value ) ) {
+                        $collected = [];
+                        array_walk_recursive(
+                                $value,
+                                static function ( $item ) use ( &$collected ): void {
+                                        if ( null === $item ) {
+                                                return;
+                                        }
+
+                                        $item = (string) $item;
+                                        if ( '' === $item ) {
+                                                return;
+                                        }
+
+                                        $collected[] = $item;
+                                }
+                        );
+
+                        if ( empty( $collected ) ) {
+                                return '';
+                        }
+
+                        $value = implode( ',', array_unique( $collected ) );
+                }
+
+                if ( $value instanceof DateTimeInterface ) {
+                        return $value->format( 'Y-m-d H:i:s' );
+                }
+
+                $string = self::cast_to_string( $value );
+                if ( '' === $string ) {
+                        return '';
+                }
+
+                $parts = array_filter(
+                        array_map( 'trim', explode( ',', $string ) ),
+                        static function ( string $part ): bool {
+                                return '' !== $part;
+                        }
+                );
+
+                if ( empty( $parts ) ) {
+                        return '';
+                }
+
+                $unique = array_values( array_unique( $parts ) );
+
+                return implode( ',', $unique );
+        }
+
+        /**
+         * Cast generic values to string.
+         *
+         * @param mixed $value Value to cast.
+         * @return string String representation.
+         */
+        private static function cast_to_string( $value ): string {
+                if ( null === $value ) {
+                        return '';
+                }
+
+                if ( $value instanceof DateTimeInterface ) {
+                        return $value->format( 'Y-m-d H:i:s' );
+                }
+
+                if ( is_bool( $value ) ) {
+                        return $value ? '1' : '0';
+                }
+
+                if ( is_scalar( $value ) ) {
+                        return (string) $value;
+                }
+
+                if ( is_array( $value ) || is_object( $value ) ) {
+                        $encoder = function_exists( 'wp_json_encode' ) ? 'wp_json_encode' : 'json_encode';
+                        $encoded = $encoder( $value );
+
+                        return is_string( $encoded ) ? $encoded : '';
+                }
+
+                return '';
+        }
+}

--- a/src/Tools/Exports/CsvExporter.php
+++ b/src/Tools/Exports/CsvExporter.php
@@ -72,8 +72,11 @@ class CsvExporter {
 			return;
 		}
 
-		fputcsv( $handle, self::sanitize_row( $row ), $separator );
-	}
+                $enclosure = '"';
+                $escape = '\\';
+
+                fputcsv( $handle, self::sanitize_row( $row ), $separator, $enclosure, $escape );
+        }
 
 	/**
 	 * Convert a row to a CSV string.


### PR DESCRIPTION
## Summary
- add a dedicated `ConversionsExporter` that normalizes conversion event rows, timestamps, and identifiers for CSV output
- expand conversion export queries and admin CSV generation to expose all table columns while guarding decoded attributes and repository responses
- tighten conversion event retrieval and segmentation logic by handling null datasets, reusing prefetched user events, sanitizing user IDs, and making recency checks resilient
- specify the CSV escape character to silence upcoming fputcsv deprecation warnings

## Testing
- `./vendor/bin/phpunit tests/ConversionEventsTest.php` *(fails: requires WordPress upgrade.php include in test environment)*
- `./vendor/bin/phpunit tests/AudienceSegmentationTest.php` *(fails: requires WordPress upgrade.php include in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d41f758ddc832f9cfec573d17e7343