### PR TITLE
Ensure cron jobs are unscheduled on deactivation

### DIFF
--- a/fp-digital-marketing-suite.php
+++ b/fp-digital-marketing-suite.php
@@ -194,10 +194,36 @@ register_deactivation_hook( __FILE__, function () {
 		if ( class_exists( '\FP\DigitalMarketing\Helpers\Capabilities' ) ) {
 			\FP\DigitalMarketing\Helpers\Capabilities::remove_capabilities();
 		}
-		
+
+		// Unschedule cron events registered by the plugin.
+		if ( class_exists( '\FP\DigitalMarketing\Helpers\SyncEngine' ) ) {
+			\FP\DigitalMarketing\Helpers\SyncEngine::unschedule_sync();
+		}
+
+		if ( class_exists( '\FP\DigitalMarketing\Helpers\ReportScheduler' ) ) {
+			\FP\DigitalMarketing\Helpers\ReportScheduler::unschedule_reports();
+		}
+
+		if ( class_exists( '\FP\DigitalMarketing\Helpers\PerformanceCache' ) ) {
+			\FP\DigitalMarketing\Helpers\PerformanceCache::unschedule_cache_warmup();
+		}
+
+		if ( class_exists( '\FP\DigitalMarketing\Helpers\SegmentationEngine' ) ) {
+			\FP\DigitalMarketing\Helpers\SegmentationEngine::unschedule_full_evaluation();
+		}
+
+		if ( class_exists( '\FP\DigitalMarketing\Helpers\EmailNotifications' ) ) {
+			\FP\DigitalMarketing\Helpers\EmailNotifications::unschedule_daily_digest();
+		}
+
+		if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+			wp_clear_scheduled_hook( 'fp_dms_cleanup_exports' );
+			wp_clear_scheduled_hook( 'fp_dms_cleanup_export_file' );
+		}
+
 		// Flush rewrite rules on deactivation.
 		flush_rewrite_rules();
-		
+
 	} catch ( \Error $e ) {
 		// Log deactivation errors but don't prevent deactivation
 		if ( function_exists( 'error_log' ) ) {

--- a/src/Helpers/EmailNotifications.php
+++ b/src/Helpers/EmailNotifications.php
@@ -678,13 +678,24 @@ class EmailNotifications {
 	 *
 	 * @return void
 	 */
-	private static function schedule_daily_digest(): void {
-		if ( ! wp_next_scheduled( 'fp_dms_daily_digest' ) ) {
-			wp_schedule_event( time(), 'daily', 'fp_dms_daily_digest' );
-		}
+        private static function schedule_daily_digest(): void {
+                if ( ! wp_next_scheduled( 'fp_dms_daily_digest' ) ) {
+                        wp_schedule_event( time(), 'daily', 'fp_dms_daily_digest' );
+                }
 
-		add_action( 'fp_dms_daily_digest', [ __CLASS__, 'send_daily_digest' ] );
-	}
+                add_action( 'fp_dms_daily_digest', [ __CLASS__, 'send_daily_digest' ] );
+        }
+
+        /**
+         * Unschedule the daily digest cron event.
+         *
+         * @return void
+         */
+        public static function unschedule_daily_digest(): void {
+                if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+                        wp_clear_scheduled_hook( 'fp_dms_daily_digest' );
+                }
+        }
 
 	/**
 	 * Send daily digest email

--- a/src/Helpers/SegmentationEngine.php
+++ b/src/Helpers/SegmentationEngine.php
@@ -64,11 +64,22 @@ class SegmentationEngine {
 	 *
 	 * @return void
 	 */
-	public static function schedule_full_evaluation(): void {
-		if ( ! wp_next_scheduled( 'fp_dms_evaluate_all_segments' ) ) {
-			wp_schedule_event( time(), 'hourly', 'fp_dms_evaluate_all_segments' );
-		}
-	}
+        public static function schedule_full_evaluation(): void {
+                if ( ! wp_next_scheduled( 'fp_dms_evaluate_all_segments' ) ) {
+                        wp_schedule_event( time(), 'hourly', 'fp_dms_evaluate_all_segments' );
+                }
+        }
+
+        /**
+         * Unschedule the periodic full segment evaluation cron event.
+         *
+         * @return void
+         */
+        public static function unschedule_full_evaluation(): void {
+                if ( function_exists( 'wp_clear_scheduled_hook' ) ) {
+                        wp_clear_scheduled_hook( 'fp_dms_evaluate_all_segments' );
+                }
+        }
 
 	/**
 	 * Evaluate segments when a new conversion event is processed


### PR DESCRIPTION
## Summary
- ensure the plugin removes all scheduled cron hooks when it is deactivated
- add helper methods for the segmentation engine and email notifications to clear their scheduled jobs safely

## Testing
- composer test *(fails: pre-existing suite errors and deprecation warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68d4426ca360832fb52ddd40b2ec1d17