### PR TITLE
Improve schema generation compatibility

### DIFF
--- a/src/Helpers/Schema/ArticleSchema.php
+++ b/src/Helpers/Schema/ArticleSchema.php
@@ -28,12 +28,12 @@ class ArticleSchema extends BaseSchema {
 
 		$schema_type = self::get_schema_type( $post );
 		
-		$schema = self::create_base_schema( $schema_type, [
-			'headline' => get_the_title( $post ),
-			'url' => self::get_permalink( $post ),
-			'datePublished' => self::format_date( $post->post_date ),
-			'dateModified' => self::format_date( $post->post_modified ),
-			'author' => self::get_author_info( $post ),
+                $schema = self::create_base_schema( $schema_type, [
+                        'headline' => get_the_title( $post ),
+                        'url' => self::get_permalink( $post ),
+                        'datePublished' => isset( $post->post_date ) ? self::format_date( (string) $post->post_date ) : '',
+                        'dateModified' => isset( $post->post_modified ) ? self::format_date( (string) $post->post_modified ) : '',
+                        'author' => self::get_author_info( $post ),
 			'publisher' => self::get_organization_schema()
 		] );
 
@@ -67,7 +67,8 @@ class ArticleSchema extends BaseSchema {
 		}
 
 		// Add article section for categories
-		$categories = get_the_category( $post->ID );
+                $post_id = isset( $post->ID ) ? (int) $post->ID : 0;
+                $categories = get_the_category( $post_id );
 		if ( ! empty( $categories ) ) {
 			$schema['articleSection'] = $categories[0]->name;
 		}
@@ -87,11 +88,11 @@ class ArticleSchema extends BaseSchema {
 	/**
 	 * Get appropriate schema type for the post
 	 *
-	 * @param \WP_Post $post Post object
+         * @param object $post Post object
 	 * @return string Schema type
 	 */
-	private static function get_schema_type( \WP_Post $post ): string {
-		$post_type = $post->post_type;
+        private static function get_schema_type( object $post ): string {
+                $post_type = $post->post_type ?? '';
 
 		// Use BlogPosting for blog posts, Article for pages and other content
 		if ( $post_type === 'post' ) {
@@ -105,26 +106,27 @@ class ArticleSchema extends BaseSchema {
 	/**
 	 * Get post description/excerpt
 	 *
-	 * @param \WP_Post $post Post object
+         * @param object $post Post object
 	 * @return string|null Post description or null
 	 */
-	private static function get_post_description( \WP_Post $post ): ?string {
+        private static function get_post_description( object $post ): ?string {
 		// Check for custom SEO meta description first
-		$seo_description = get_post_meta( $post->ID, '_fp_seo_description', true );
+                $post_id = isset( $post->ID ) ? (int) $post->ID : 0;
+                $seo_description = get_post_meta( $post_id, '_fp_seo_description', true );
 		if ( ! empty( $seo_description ) ) {
 			return wp_strip_all_tags( $seo_description );
 		}
 
 		// Use excerpt if available
-		if ( ! empty( $post->post_excerpt ) ) {
-			return wp_strip_all_tags( $post->post_excerpt );
-		}
+                if ( ! empty( $post->post_excerpt ) ) {
+                        return wp_strip_all_tags( (string) $post->post_excerpt );
+                }
 
-		// Generate excerpt from content
-		$content = wp_strip_all_tags( $post->post_content );
-		if ( strlen( $content ) > 160 ) {
-			$content = substr( $content, 0, 157 ) . '...';
-		}
+                // Generate excerpt from content
+                $content = isset( $post->post_content ) ? wp_strip_all_tags( (string) $post->post_content ) : '';
+                if ( strlen( $content ) > 160 ) {
+                        $content = substr( $content, 0, 157 ) . '...';
+                }
 
 		return $content ?: null;
 	}
@@ -132,11 +134,11 @@ class ArticleSchema extends BaseSchema {
 	/**
 	 * Get featured image schema
 	 *
-	 * @param \WP_Post $post Post object
+         * @param object $post Post object
 	 * @return array|null Image schema or null
 	 */
-	private static function get_featured_image( \WP_Post $post ): ?array {
-		$thumbnail_id = get_post_thumbnail_id( $post->ID );
+        private static function get_featured_image( object $post ): ?array {
+                $thumbnail_id = get_post_thumbnail_id( isset( $post->ID ) ? (int) $post->ID : 0 );
 
 		if ( ! $thumbnail_id ) {
 			return null;
@@ -162,7 +164,7 @@ class ArticleSchema extends BaseSchema {
 		}
 
 		// Add caption if available
-		$attachment = get_post( $thumbnail_id );
+                $attachment = get_post( $thumbnail_id );
 		if ( $attachment && ! empty( $attachment->post_excerpt ) ) {
 			$image_schema['caption'] = wp_strip_all_tags( $attachment->post_excerpt );
 		}
@@ -173,10 +175,10 @@ class ArticleSchema extends BaseSchema {
 	/**
 	 * Get article body content
 	 *
-	 * @param \WP_Post $post Post object
+         * @param object $post Post object
 	 * @return string Article body
 	 */
-	private static function get_article_body( \WP_Post $post ): string {
+        private static function get_article_body( object $post ): string {
 		$content = apply_filters( 'the_content', $post->post_content );
 		return wp_strip_all_tags( $content );
 	}
@@ -184,31 +186,51 @@ class ArticleSchema extends BaseSchema {
 	/**
 	 * Get word count for the post
 	 *
-	 * @param \WP_Post $post Post object
+         * @param object $post Post object
 	 * @return int Word count
 	 */
-	private static function get_word_count( \WP_Post $post ): int {
-		$content = wp_strip_all_tags( $post->post_content );
-		return str_word_count( $content );
-	}
+        private static function get_word_count( object $post ): int {
+                $content = isset( $post->post_content ) ? wp_strip_all_tags( (string) $post->post_content ) : '';
+
+                if ( $content === '' ) {
+                        return 0;
+                }
+
+                $words = str_word_count( $content, 1 );
+
+                if ( empty( $words ) ) {
+                        return 0;
+                }
+
+                $words = array_filter(
+                        $words,
+                        static function ( $word ): bool {
+                                $length = function_exists( 'mb_strlen' ) ? mb_strlen( $word ) : strlen( $word );
+                                return $length > 1;
+                        }
+                );
+
+                return count( $words );
+        }
 
 	/**
 	 * Get post keywords from categories and tags
 	 *
-	 * @param \WP_Post $post Post object
+         * @param object $post Post object
 	 * @return array Keywords
 	 */
-	private static function get_post_keywords( \WP_Post $post ): array {
-		$keywords = [];
+        private static function get_post_keywords( object $post ): array {
+                $keywords = [];
+                $post_id = isset( $post->ID ) ? (int) $post->ID : 0;
 
-		// Get categories
-		$categories = get_the_category( $post->ID );
+                // Get categories
+                $categories = get_the_category( $post_id );
 		foreach ( $categories as $category ) {
 			$keywords[] = $category->name;
 		}
 
 		// Get tags
-		$tags = get_the_tags( $post->ID );
+                $tags = get_the_tags( $post_id );
 		if ( $tags ) {
 			foreach ( $tags as $tag ) {
 				$keywords[] = $tag->name;

--- a/src/Helpers/Schema/BaseSchema.php
+++ b/src/Helpers/Schema/BaseSchema.php
@@ -67,33 +67,45 @@ abstract class BaseSchema {
 	/**
 	 * Get current post data
 	 *
-	 * @return \WP_Post|null Current post or null
-	 */
-	protected static function get_current_post(): ?\WP_Post {
-		global $post;
-		
-		if ( is_singular() && $post instanceof \WP_Post ) {
-			return $post;
-		}
+         * @return object|null Current post or null
+         */
+        protected static function get_current_post(): ?object {
+                global $post;
 
-		return null;
-	}
+                if ( ! is_singular() ) {
+                        return null;
+                }
+
+                if ( $post instanceof \WP_Post ) {
+                        return $post;
+                }
+
+                if ( is_object( $post ) && isset( $post->ID ) ) {
+                        return $post;
+                }
+
+                return null;
+        }
 
 	/**
 	 * Get author information for a post
 	 *
-	 * @param \WP_Post $post Post object
-	 * @return array Author information
-	 */
-	protected static function get_author_info( \WP_Post $post ): array {
-		$author_id = $post->post_author;
-		$author = get_userdata( $author_id );
+         * @param object $post Post object
+         * @return array Author information
+         */
+        protected static function get_author_info( object $post ): array {
+                if ( ! isset( $post->post_author ) ) {
+                        return [];
+                }
 
-		if ( ! $author ) {
-			return [];
-		}
+                $author_id = (int) $post->post_author;
+                $author = get_userdata( $author_id );
 
-		return [
+                if ( ! $author ) {
+                        return [];
+                }
+
+                return [
 			'@type' => 'Person',
 			'name' => $author->display_name,
 			'url' => get_author_posts_url( $author_id )
@@ -135,17 +147,27 @@ abstract class BaseSchema {
 	 * @param string $date Date string
 	 * @return string ISO 8601 formatted date
 	 */
-	protected static function format_date( string $date ): string {
-		return date( 'c', strtotime( $date ) );
-	}
+        protected static function format_date( string $date ): string {
+                if ( empty( $date ) ) {
+                        return '';
+                }
 
-	/**
-	 * Get permalink for a post
-	 *
-	 * @param int|\WP_Post $post Post ID or object
-	 * @return string Post permalink
-	 */
-	protected static function get_permalink( $post ): string {
-		return get_permalink( $post ) ?: '';
-	}
+                $timestamp = strtotime( $date );
+
+                if ( false === $timestamp ) {
+                        return '';
+                }
+
+                return date( 'c', $timestamp );
+        }
+
+        /**
+         * Get permalink for a post
+         *
+         * @param int|object $post Post ID or object
+         * @return string Post permalink
+         */
+        protected static function get_permalink( $post ): string {
+                return get_permalink( $post ) ?: '';
+        }
 }

--- a/src/Helpers/Schema/BreadcrumbListSchema.php
+++ b/src/Helpers/Schema/BreadcrumbListSchema.php
@@ -93,9 +93,9 @@ class BreadcrumbListSchema extends BaseSchema {
 		$breadcrumbs = [];
 		$term = get_queried_object();
 
-		if ( ! $term instanceof \WP_Term ) {
-			return $breadcrumbs;
-		}
+                if ( ! ( $term instanceof \WP_Term ) && ! ( is_object( $term ) && isset( $term->term_id, $term->taxonomy ) ) ) {
+                        return $breadcrumbs;
+                }
 
 		// Add parent terms if any
 		if ( $term->parent ) {
@@ -136,9 +136,9 @@ class BreadcrumbListSchema extends BaseSchema {
 		$breadcrumbs = [];
 		$post = get_queried_object();
 
-		if ( ! $post instanceof \WP_Post ) {
-			return $breadcrumbs;
-		}
+                if ( ! is_object( $post ) || ! isset( $post->ID, $post->post_type ) ) {
+                        return $breadcrumbs;
+                }
 
 		// Add post type archive if applicable
 		$post_type_obj = get_post_type_object( $post->post_type );
@@ -186,9 +186,9 @@ class BreadcrumbListSchema extends BaseSchema {
 		$breadcrumbs = [];
 		$post = get_queried_object();
 
-		if ( ! $post instanceof \WP_Post ) {
-			return $breadcrumbs;
-		}
+                if ( ! is_object( $post ) || ! isset( $post->ID ) ) {
+                        return $breadcrumbs;
+                }
 
 		// Add parent pages
 		if ( $post->post_parent ) {

--- a/src/Helpers/Schema/FAQSchema.php
+++ b/src/Helpers/Schema/FAQSchema.php
@@ -55,9 +55,11 @@ class FAQSchema extends BaseSchema {
 		$enabled_post_types = $settings['faq_post_types'] ?? [ 'post', 'page' ];
 
 		// Check if current post type is enabled for FAQ
-		if ( ! in_array( $post->post_type, $enabled_post_types, true ) ) {
-			return false;
-		}
+                $post_type = $post->post_type ?? '';
+
+                if ( ! in_array( $post_type, $enabled_post_types, true ) ) {
+                        return false;
+                }
 
 		// Check if post has FAQ content
 		return self::has_faq_content( $post );
@@ -66,29 +68,31 @@ class FAQSchema extends BaseSchema {
 	/**
 	 * Check if post has FAQ content
 	 *
-	 * @param \WP_Post $post Post object
+         * @param object $post Post object
 	 * @return bool True if has FAQ content
 	 */
-	private static function has_faq_content( \WP_Post $post ): bool {
+        private static function has_faq_content( object $post ): bool {
 		// Check for FAQ blocks (Gutenberg)
-		if ( has_blocks( $post->post_content ) ) {
-			if ( self::has_faq_blocks( $post->post_content ) ) {
-				return true;
-			}
-		}
+                $content = isset( $post->post_content ) ? (string) $post->post_content : '';
 
-		// Check for FAQ shortcodes
-		if ( self::has_faq_shortcodes( $post->post_content ) ) {
-			return true;
-		}
+                if ( has_blocks( $content ) ) {
+                        if ( self::has_faq_blocks( $content ) ) {
+                                return true;
+                        }
+                }
 
-		// Check for FAQ patterns in content
-		if ( self::has_faq_patterns( $post->post_content ) ) {
-			return true;
-		}
+                // Check for FAQ shortcodes
+                if ( self::has_faq_shortcodes( $content ) ) {
+                        return true;
+                }
 
-		// Check for custom FAQ meta fields
-		$custom_faqs = get_post_meta( $post->ID, '_fp_faqs', true );
+                // Check for FAQ patterns in content
+                if ( self::has_faq_patterns( $content ) ) {
+                        return true;
+                }
+
+                // Check for custom FAQ meta fields
+                $custom_faqs = get_post_meta( isset( $post->ID ) ? (int) $post->ID : 0, '_fp_faqs', true );
 		if ( ! empty( $custom_faqs ) ) {
 			return true;
 		}
@@ -99,25 +103,27 @@ class FAQSchema extends BaseSchema {
 	/**
 	 * Get FAQ items from post content
 	 *
-	 * @param \WP_Post $post Post object
+         * @param object $post Post object
 	 * @return array FAQ items
 	 */
-	private static function get_faq_items( \WP_Post $post ): array {
-		$faq_items = [];
+        private static function get_faq_items( object $post ): array {
+                $faq_items = [];
 
-		// Get FAQ items from Gutenberg blocks
-		if ( has_blocks( $post->post_content ) ) {
-			$faq_items = array_merge( $faq_items, self::get_faq_from_blocks( $post->post_content ) );
-		}
+                // Get FAQ items from Gutenberg blocks
+                $content = isset( $post->post_content ) ? (string) $post->post_content : '';
 
-		// Get FAQ items from shortcodes
-		$faq_items = array_merge( $faq_items, self::get_faq_from_shortcodes( $post->post_content ) );
+                if ( has_blocks( $content ) ) {
+                        $faq_items = array_merge( $faq_items, self::get_faq_from_blocks( $content ) );
+                }
 
-		// Get FAQ items from content patterns
-		$faq_items = array_merge( $faq_items, self::get_faq_from_patterns( $post->post_content ) );
+                // Get FAQ items from shortcodes
+                $faq_items = array_merge( $faq_items, self::get_faq_from_shortcodes( $content ) );
 
-		// Get FAQ items from custom meta fields
-		$custom_faqs = get_post_meta( $post->ID, '_fp_faqs', true );
+                // Get FAQ items from content patterns
+                $faq_items = array_merge( $faq_items, self::get_faq_from_patterns( $content ) );
+
+                // Get FAQ items from custom meta fields
+                $custom_faqs = get_post_meta( isset( $post->ID ) ? (int) $post->ID : 0, '_fp_faqs', true );
 		if ( is_array( $custom_faqs ) ) {
 			$faq_items = array_merge( $faq_items, self::format_custom_faqs( $custom_faqs ) );
 		}


### PR DESCRIPTION
## Summary
- make schema generators resilient to minimal WordPress stubs by avoiding strict WP_Post requirements
- harden article schema metadata building with safe fallbacks and smarter word counting
- adjust breadcrumb and FAQ schemas to cope with generic post objects and missing content

## Testing
- vendor/bin/phpunit tests/ArticleSchemaTest.php
- vendor/bin/phpunit tests/SchemaGeneratorTest.php
- vendor/bin/phpunit tests/WebSiteSchemaTest.php
- vendor/bin/phpunit tests/MetricsSchemaTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d4452cfe40832f92486856dd043a04