### PR TITLE
Align asset versioning with plugin release

### DIFF
--- a/src/Admin/Dashboard.php
+++ b/src/Admin/Dashboard.php
@@ -160,14 +160,18 @@ class Dashboard {
 			true
 		);
 
-                // Enqueue dashboard script
-                wp_enqueue_script(
-                        'fp-dms-dashboard',
-                        FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/dashboard.js',
-                        [ 'jquery', 'chartjs' ],
-                        '1.0.0',
-                        true
-                );
+		$asset_version = defined( 'FP_DIGITAL_MARKETING_VERSION' )
+			? FP_DIGITAL_MARKETING_VERSION
+			: '1.0.0';
+
+		// Enqueue dashboard script
+		wp_enqueue_script(
+			'fp-dms-dashboard',
+			FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/dashboard.js',
+			[ 'jquery', 'chartjs' ],
+			$asset_version,
+			true
+		);
 
                 // Localize script for AJAX
 		wp_localize_script( 'fp-dms-dashboard', 'fpDmsDashboard', [

--- a/src/Admin/SegmentationAdmin.php
+++ b/src/Admin/SegmentationAdmin.php
@@ -80,20 +80,24 @@ class SegmentationAdmin {
 			return;
 		}
 
-                wp_enqueue_style(
-                        'fp-segmentation-admin',
-                        FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/css/segmentation-admin.css',
-                        [],
-                        '1.0.0'
-                );
+		$asset_version = defined( 'FP_DIGITAL_MARKETING_VERSION' )
+			? FP_DIGITAL_MARKETING_VERSION
+			: '1.0.0';
 
-                wp_enqueue_script(
-                        'fp-segmentation-admin',
-                        FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/segmentation-admin.js',
-                        [ 'jquery', 'wp-util' ],
-                        '1.0.0',
-                        true
-                );
+		wp_enqueue_style(
+			'fp-segmentation-admin',
+			FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/css/segmentation-admin.css',
+			[],
+			$asset_version
+		);
+
+		wp_enqueue_script(
+			'fp-segmentation-admin',
+			FP_DIGITAL_MARKETING_PLUGIN_URL . 'assets/js/segmentation-admin.js',
+			[ 'jquery', 'wp-util' ],
+			$asset_version,
+			true
+		);
 
 		wp_localize_script( 'fp-segmentation-admin', 'fpSegmentation', [
 			'nonce' => wp_create_nonce( self::NONCE_ACTION ),

--- a/src/DigitalMarketingSuite.php
+++ b/src/DigitalMarketingSuite.php
@@ -194,6 +194,9 @@ class DigitalMarketingSuite {
 	 * Constructor with error handling
 	 */
 	public function __construct() {
+		if ( defined( 'FP_DIGITAL_MARKETING_VERSION' ) ) {
+			$this->version = FP_DIGITAL_MARKETING_VERSION;
+		}
 		// Initialize components with error handling to prevent WSOD
 		try {
 			$this->cliente_post_type = new ClientePostType();

--- a/src/Helpers/FAQBlock.php
+++ b/src/Helpers/FAQBlock.php
@@ -67,14 +67,19 @@ class FAQBlock {
 
 		// Only enqueue if the file exists
 		if ( file_exists( $script_path ) ) {
+			$asset_version = defined( 'FP_DIGITAL_MARKETING_VERSION' )
+				? FP_DIGITAL_MARKETING_VERSION
+				: '1.0.0';
+
 			wp_enqueue_script(
 				'fp-dms-faq-block',
 				$script_url,
 				[ 'wp-blocks', 'wp-editor', 'wp-components', 'wp-element' ],
-				'1.0.0',
+				$asset_version,
 				true
 			);
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- synchronize the main DigitalMarketingSuite version property with the global plugin constant during construction
- reuse the plugin version constant when enqueueing dashboard, segmentation, and FAQ block assets so cache busting follows releases

## Testing
- `composer run phpstan` *(fails: existing WordPress symbols and custom mocks are missing from the analysis context)*
- `composer test` *(fails: suite depends on WordPress database helpers and other runtime integrations that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44910e508832faa5b13d2296de095