### PR TITLE
Add Site Health checks and cron scheduling safeguards

### DIFF
--- a/src/DigitalMarketingSuite.php
+++ b/src/DigitalMarketingSuite.php
@@ -51,6 +51,8 @@ use FP\DigitalMarketing\Helpers\Capabilities;
 use FP\DigitalMarketing\Helpers\DashboardWidgets;
 use FP\DigitalMarketing\Helpers\DataExporter;
 use FP\DigitalMarketing\Helpers\EmailNotifications;
+use FP\DigitalMarketing\Helpers\PerformanceCache;
+use FP\DigitalMarketing\Helpers\SiteHealth;
 
 /**
  * Main application class
@@ -629,6 +631,23 @@ class DigitalMarketingSuite {
 			}
 		} catch ( \Throwable $e ) {
 			$this->log_initialization_error( 'EmailNotifications::init()', $e );
+		}
+
+		// Ensure recurring helper events are scheduled
+		try {
+			if ( class_exists( '\FP\DigitalMarketing\Helpers\PerformanceCache' ) ) {
+				PerformanceCache::schedule_cache_warmup();
+			}
+		} catch ( \Throwable $e ) {
+			$this->log_initialization_error( 'PerformanceCache::schedule_cache_warmup()', $e );
+		}
+
+		try {
+			if ( class_exists( '\FP\DigitalMarketing\Helpers\SiteHealth' ) ) {
+				SiteHealth::init();
+			}
+		} catch ( \Throwable $e ) {
+			$this->log_initialization_error( 'SiteHealth::init()', $e );
 		}
 
 		// Schedule cleanup tasks with error handling

--- a/src/Helpers/SiteHealth.php
+++ b/src/Helpers/SiteHealth.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Site Health integration for FP Digital Marketing Suite.
+ *
+ * @package FP_Digital_Marketing_Suite
+ */
+
+declare(strict_types=1);
+
+namespace FP\DigitalMarketing\Helpers;
+
+use FP\DigitalMarketing\Database\AudienceSegmentTable;
+use FP\DigitalMarketing\Database\CustomerJourneyTable;
+use FP\DigitalMarketing\Database\CustomReportsTable;
+use FP\DigitalMarketing\Database\DetectedAnomaliesTable;
+use FP\DigitalMarketing\Database\FunnelTable;
+use FP\DigitalMarketing\Database\MetricsCacheTable;
+use FP\DigitalMarketing\Database\SocialSentimentTable;
+use FP\DigitalMarketing\Database\ConversionEventsTable;
+use FP\DigitalMarketing\Database\UTMCampaignsTable;
+use FP\DigitalMarketing\Database\AlertRulesTable;
+use FP\DigitalMarketing\Database\AnomalyRulesTable;
+use FP\DigitalMarketing\Helpers\PerformanceCache;
+
+/**
+ * Registers custom Site Health checks that help administrators verify
+ * that the plugin is correctly configured in production environments.
+ */
+class SiteHealth {
+
+        /**
+         * Prefix used for identifying Site Health tests registered by the plugin.
+         */
+        private const TEST_PREFIX = 'fp_dms_';
+
+        /**
+         * Initialize the Site Health integration.
+         *
+         * @return void
+         */
+        public static function init(): void {
+                if ( ! function_exists( 'add_filter' ) ) {
+                        return;
+                }
+
+                add_filter( 'site_status_tests', [ self::class, 'register_tests' ] );
+        }
+
+        /**
+         * Register plugin specific Site Health tests.
+         *
+         * @param array<string, mixed> $tests Existing tests.
+         * @return array<string, mixed>
+         */
+        public static function register_tests( array $tests ): array {
+                $tests['direct'][ self::TEST_PREFIX . 'database' ] = [
+                        'label' => __( 'FP Digital Marketing Suite database tables', 'fp-digital-marketing' ),
+                        'test'  => [ self::class, 'test_database_tables' ],
+                ];
+
+                $tests['direct'][ self::TEST_PREFIX . 'scheduled_events' ] = [
+                        'label' => __( 'FP Digital Marketing Suite scheduled events', 'fp-digital-marketing' ),
+                        'test'  => [ self::class, 'test_scheduled_events' ],
+                ];
+
+                return $tests;
+        }
+
+        /**
+         * Verify that required database tables exist.
+         *
+         * @return array<string, mixed>
+         */
+        public static function test_database_tables(): array {
+                $missing_tables = [];
+
+                $table_checks = [
+                        'metrics_cache' => static function(): bool {
+                                return class_exists( MetricsCacheTable::class ) && MetricsCacheTable::table_exists();
+                        },
+                        'conversion_events' => static function(): bool {
+                                return class_exists( ConversionEventsTable::class ) && ConversionEventsTable::table_exists();
+                        },
+                        'audience_segments' => static function(): bool {
+                                return class_exists( AudienceSegmentTable::class ) && AudienceSegmentTable::segments_table_exists();
+                        },
+                        'audience_membership' => static function(): bool {
+                                return class_exists( AudienceSegmentTable::class ) && AudienceSegmentTable::membership_table_exists();
+                        },
+                        'utm_campaigns' => static function(): bool {
+                                return class_exists( UTMCampaignsTable::class ) && UTMCampaignsTable::table_exists();
+                        },
+                        'funnels' => static function(): bool {
+                                return class_exists( FunnelTable::class ) && FunnelTable::table_exists() && FunnelTable::stages_table_exists();
+                        },
+                        'customer_journeys' => static function(): bool {
+                                return class_exists( CustomerJourneyTable::class ) && CustomerJourneyTable::table_exists() && CustomerJourneyTable::sessions_table_exists();
+                        },
+                        'custom_reports' => static function(): bool {
+                                return class_exists( CustomReportsTable::class ) && CustomReportsTable::table_exists();
+                        },
+                        'social_sentiment' => static function(): bool {
+                                return class_exists( SocialSentimentTable::class ) && SocialSentimentTable::table_exists();
+                        },
+                        'alert_rules' => static function(): bool {
+                                return class_exists( AlertRulesTable::class ) && AlertRulesTable::table_exists();
+                        },
+                        'anomaly_rules' => static function(): bool {
+                                return class_exists( AnomalyRulesTable::class ) && AnomalyRulesTable::table_exists();
+                        },
+                        'detected_anomalies' => static function(): bool {
+                                return class_exists( DetectedAnomaliesTable::class ) && DetectedAnomaliesTable::table_exists();
+                        },
+                ];
+
+                foreach ( $table_checks as $name => $callback ) {
+                        try {
+                                if ( ! $callback() ) {
+                                        $missing_tables[] = $name;
+                                }
+                        } catch ( \Throwable $error ) {
+                                $missing_tables[] = $name;
+                        }
+                }
+
+                if ( empty( $missing_tables ) ) {
+                        return self::build_result(
+                                'database',
+                                'good',
+                                __( 'Tutte le tabelle richieste dal plugin sono state trovate.', 'fp-digital-marketing' )
+                        );
+                }
+
+                $missing_list = implode( ', ', array_map( [ self::class, 'escape_text' ], $missing_tables ) );
+
+                $description  = sprintf(
+                        /* translators: %s: missing table names */
+                        __( 'Le seguenti tabelle del plugin risultano mancanti: %s. Esegui nuovamente l\'attivazione del plugin per ricrearle oppure verifica i permessi del database.', 'fp-digital-marketing' ),
+                        $missing_list
+                );
+
+                return self::build_result( 'database', 'critical', $description );
+        }
+
+        /**
+         * Check that scheduled events are registered.
+         *
+         * @return array<string, mixed>
+         */
+        public static function test_scheduled_events(): array {
+                if ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON ) {
+                        return self::build_result(
+                                'scheduled_events',
+                                'recommended',
+                                __( 'WP-Cron risulta disabilitato. Alcune automazioni del plugin potrebbero non essere eseguite.', 'fp-digital-marketing' )
+                        );
+                }
+
+                if ( ! function_exists( 'wp_next_scheduled' ) ) {
+                        return self::build_result(
+                                'scheduled_events',
+                                'recommended',
+                                __( 'Impossibile verificare gli eventi pianificati perché wp_next_scheduled() non è disponibile.', 'fp-digital-marketing' )
+                        );
+                }
+
+                $scheduled_hooks = [
+                        'fp_dms_sync_data_sources'  => [
+                                'label'   => __( 'Sincronizzazione sorgenti dati', 'fp-digital-marketing' ),
+                                'enabled' => static function(): bool {
+                                        $settings = get_option( 'fp_digital_marketing_sync_settings', [] );
+                                        return is_array( $settings ) && ! empty( $settings['enable_sync'] );
+                                },
+                        ],
+                        'fp_dms_generate_reports'   => [
+                                'label'   => __( 'Generazione report programmati', 'fp-digital-marketing' ),
+                                'enabled' => static function(): bool {
+                                        return true;
+                                },
+                        ],
+                        'fp_dms_evaluate_all_segments' => [
+                                'label'   => __( 'Valutazione segmenti audience', 'fp-digital-marketing' ),
+                                'enabled' => static function(): bool {
+                                        return true;
+                                },
+                        ],
+                        'fp_dms_cache_warmup'       => [
+                                'label'   => __( 'Pre-caricamento cache performance', 'fp-digital-marketing' ),
+                                'enabled' => static function(): bool {
+                                        return PerformanceCache::is_cache_enabled();
+                                },
+                        ],
+                        'fp_dms_daily_digest'       => [
+                                'label'   => __( 'Riepilogo email giornaliero', 'fp-digital-marketing' ),
+                                'enabled' => static function(): bool {
+                                        $settings = get_option( 'fp_digital_marketing_email_settings', [] );
+                                        return is_array( $settings ) && ( $settings['daily_digest_enabled'] ?? false );
+                                },
+                        ],
+                ];
+
+                $missing_events = [];
+
+                foreach ( $scheduled_hooks as $hook => $metadata ) {
+                        try {
+                                if ( is_callable( $metadata['enabled'] ) && ! $metadata['enabled']() ) {
+                                        continue;
+                                }
+
+                                if ( false === wp_next_scheduled( $hook ) ) {
+                                        $missing_events[] = $metadata['label'];
+                                }
+                        } catch ( \Throwable $error ) {
+                                $missing_events[] = $metadata['label'];
+                        }
+                }
+
+                if ( empty( $missing_events ) ) {
+                        return self::build_result(
+                                'scheduled_events',
+                                'good',
+                                __( 'Tutti gli eventi pianificati critici risultano programmati.', 'fp-digital-marketing' )
+                        );
+                }
+
+                $missing_list = implode( ', ', array_map( [ self::class, 'escape_text' ], $missing_events ) );
+                $description  = sprintf(
+                        /* translators: %s: list of missing events */
+                        __( 'Gli eventi pianificati mancanti sono: %s. Verifica che il cron di WordPress sia attivo e ri-salva le impostazioni del plugin per riprogrammarli.', 'fp-digital-marketing' ),
+                        $missing_list
+                );
+
+                return self::build_result( 'scheduled_events', 'recommended', $description );
+        }
+
+        /**
+         * Build a Site Health test response.
+         *
+         * @param string $slug        Test slug suffix.
+         * @param string $status      Status (good|recommended|critical).
+         * @param string $description Description text.
+         * @return array<string, mixed>
+         */
+        private static function build_result( string $slug, string $status, string $description ): array {
+                return [
+                        'label'       => __( 'FP Digital Marketing Suite', 'fp-digital-marketing' ),
+                        'status'      => $status,
+                        'badge'       => [
+                                'label' => __( 'FP DMS', 'fp-digital-marketing' ),
+                                'color' => 'blue',
+                        ],
+                        'description' => sprintf( '<p>%s</p>', $description ),
+                        'actions'     => [],
+                        'test'        => self::TEST_PREFIX . $slug,
+                ];
+        }
+
+        /**
+         * Escape a string for safe HTML output even when esc_html() is unavailable.
+         *
+         * @param string $value Raw string value.
+         * @return string Escaped string.
+         */
+        private static function escape_text( string $value ): string {
+                if ( function_exists( 'esc_html' ) ) {
+                        return esc_html( $value );
+                }
+
+                return htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
+        }
+}

--- a/tests/SiteHealthTest.php
+++ b/tests/SiteHealthTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Tests for SiteHealth helper.
+ *
+ * @package FP_Digital_Marketing_Suite
+ */
+
+use PHPUnit\Framework\TestCase;
+use FP\DigitalMarketing\Helpers\SiteHealth;
+
+/**
+ * Minimal wpdb stub for Site Health tests.
+ */
+class SiteHealthWPDBStub {
+        /**
+         * WordPress table prefix.
+         *
+         * @var string
+         */
+        public string $prefix = 'wp_';
+
+        /**
+         * List of tables that should be reported as existing.
+         *
+         * @var array<int, string>
+         */
+        private array $existing_tables = [];
+
+        /**
+         * Update the list of tables reported as existing.
+         *
+         * @param array<int, string> $tables Table names.
+         * @return void
+         */
+        public function set_existing_tables( array $tables ): void {
+                $this->existing_tables = $tables;
+        }
+
+        /**
+         * Simulate wpdb::prepare.
+         *
+         * @param string $query SQL query.
+         * @param mixed  ...$args Arguments.
+         * @return string
+         */
+        public function prepare( string $query, ...$args ): string { // phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag
+                if ( strpos( $query, '%s' ) !== false && ! empty( $args ) ) {
+                        $replacements = array_map(
+                                static function ( $arg ) {
+                                        return "'" . $arg . "'";
+                                },
+                                $args
+                        );
+
+                        foreach ( $replacements as $replacement ) {
+                                $query = preg_replace( '/%s/', $replacement, $query, 1 );
+                        }
+                }
+
+                return $query;
+        }
+
+        /**
+         * Simulate wpdb::get_var.
+         *
+         * @param string $query Prepared query.
+         * @return string|null
+         */
+        public function get_var( string $query ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+                if ( preg_match( "/SHOW TABLES LIKE '([^']+)'/", $query, $matches ) ) {
+                        $table = $matches[1];
+
+                        if ( in_array( $table, $this->existing_tables, true ) ) {
+                                return $table;
+                        }
+
+                        return null;
+                }
+
+                return null;
+        }
+}
+
+/**
+ * @covers \FP\DigitalMarketing\Helpers\SiteHealth
+ */
+class SiteHealthTest extends TestCase {
+
+        /**
+         * Original wpdb instance.
+         *
+         * @var mixed
+         */
+        private $original_wpdb;
+
+        /**
+         * Original WordPress options store.
+         *
+         * @var array<string, mixed>
+         */
+        private array $original_options = [];
+
+        /**
+         * Original mocked functions map.
+         *
+         * @var array<string, callable>
+         */
+        private array $original_mock_functions = [];
+
+        protected function setUp(): void {
+                parent::setUp();
+
+                global $wpdb, $wp_options, $wp_mock_functions;
+
+                $this->original_wpdb            = $wpdb ?? null;
+                $this->original_options         = $wp_options ?? [];
+                $this->original_mock_functions  = $wp_mock_functions ?? [];
+
+                $wp_options        = $this->original_options;
+                $wp_mock_functions = $this->original_mock_functions;
+        }
+
+        protected function tearDown(): void {
+                global $wpdb, $wp_options, $wp_mock_functions;
+
+                $wpdb              = $this->original_wpdb;
+                $wp_options        = $this->original_options;
+                $wp_mock_functions = $this->original_mock_functions;
+
+                parent::tearDown();
+        }
+
+        public function test_register_tests_adds_site_health_entries(): void {
+                $tests   = [ 'direct' => [] ];
+                $result  = SiteHealth::register_tests( $tests );
+                $entries = array_keys( $result['direct'] );
+
+                $this->assertContains( 'fp_dms_database', $entries );
+                $this->assertContains( 'fp_dms_scheduled_events', $entries );
+        }
+
+        public function test_database_tables_reports_success_when_all_tables_exist(): void {
+                global $wpdb;
+
+                $stub = new SiteHealthWPDBStub();
+                $all_tables = [
+                        'wp_fp_metrics_cache',
+                        'wp_fp_conversion_events',
+                        'wp_fp_audience_segments',
+                        'wp_fp_segment_membership',
+                        'wp_fp_utm_campaigns',
+                        'wp_fp_dms_funnels',
+                        'wp_fp_dms_funnel_stages',
+                        'wp_fp_dms_customer_journeys',
+                        'wp_fp_dms_journey_sessions',
+                        'wp_fp_dms_custom_reports',
+                        'wp_fp_dms_social_sentiment',
+                        'wp_fp_alert_rules',
+                        'wp_fp_anomaly_rules',
+                        'wp_fp_detected_anomalies',
+                ];
+                $stub->set_existing_tables( $all_tables );
+
+                $wpdb = $stub;
+
+                $result = SiteHealth::test_database_tables();
+
+                $this->assertSame( 'good', $result['status'] );
+        }
+
+        public function test_database_tables_reports_critical_when_tables_missing(): void {
+                global $wpdb;
+
+                $stub = new SiteHealthWPDBStub();
+                $stub->set_existing_tables( [ 'wp_fp_metrics_cache' ] );
+
+                $wpdb = $stub;
+
+                $result = SiteHealth::test_database_tables();
+
+                $this->assertSame( 'critical', $result['status'] );
+                $this->assertStringContainsString( 'fp_conversion_events', $result['description'] );
+        }
+
+        public function test_scheduled_events_reports_good_when_all_hooks_present(): void {
+                global $wp_options, $wp_mock_functions;
+
+                $wp_options['fp_digital_marketing_sync_settings']  = [ 'enable_sync' => true ];
+                $wp_options['fp_digital_marketing_email_settings'] = [ 'daily_digest_enabled' => true ];
+
+                $scheduled = [
+                        'fp_dms_sync_data_sources'     => time() + 60,
+                        'fp_dms_generate_reports'      => time() + 120,
+                        'fp_dms_evaluate_all_segments' => time() + 180,
+                        'fp_dms_cache_warmup'          => time() + 240,
+                        'fp_dms_daily_digest'          => time() + 300,
+                ];
+
+                $wp_mock_functions['wp_next_scheduled'] = static function ( string $hook ) use ( $scheduled ) {
+                        return $scheduled[ $hook ] ?? false;
+                };
+
+                $result = SiteHealth::test_scheduled_events();
+
+                $this->assertSame( 'good', $result['status'] );
+        }
+
+        public function test_scheduled_events_reports_recommended_when_hook_missing(): void {
+                global $wp_options, $wp_mock_functions;
+
+                $wp_options['fp_digital_marketing_sync_settings']  = [ 'enable_sync' => true ];
+                $wp_options['fp_digital_marketing_email_settings'] = [ 'daily_digest_enabled' => true ];
+
+                $wp_mock_functions['wp_next_scheduled'] = static function ( string $hook ) {
+                        return 'fp_dms_generate_reports' === $hook ? false : time() + 60;
+                };
+
+                $result = SiteHealth::test_scheduled_events();
+
+                $this->assertSame( 'recommended', $result['status'] );
+                $this->assertStringContainsString( 'Generazione report programmati', $result['description'] );
+        }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -496,6 +496,11 @@ if ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 
         if ( ! function_exists( 'wp_next_scheduled' ) ) {
                 function wp_next_scheduled( $hook ) {
+                        global $wp_mock_functions;
+                        if ( isset( $wp_mock_functions['wp_next_scheduled'] ) ) {
+                                return $wp_mock_functions['wp_next_scheduled']( $hook );
+                        }
+
                         return false;
                 }
         }


### PR DESCRIPTION
## Summary
- add a SiteHealth helper that surfaces database and cron readiness checks in WordPress Site Health
- ensure recurring maintenance events are scheduled during plugin init and hook the Site Health integration
- extend the PHPUnit bootstrap and add tests covering the Site Health helper behaviour

## Testing
- composer test *(fails: phpunit binary not available in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d457349d9c832fb808889125998321