### PR TITLE
Implement GA4 API data retrieval

### DIFF
--- a/src/DataSources/GoogleAnalytics4.php
+++ b/src/DataSources/GoogleAnalytics4.php
@@ -24,12 +24,17 @@ class GoogleAnalytics4 {
 	 */
 	public const SOURCE_ID = 'google_analytics_4';
 
-	/**
-	 * OAuth client
-	 *
-	 * @var GoogleOAuth
-	 */
-	private $oauth_client;
+        /**
+         * OAuth client
+         *
+         * @var GoogleOAuth
+         */
+        private $oauth_client;
+
+        /**
+         * Google Analytics Data API base URL
+         */
+        private const API_BASE_URL = 'https://analyticsdata.googleapis.com/v1beta';
 
 	/**
 	 * GA4 property ID
@@ -142,17 +147,15 @@ class GoogleAnalytics4 {
 		}
 	}
 
-	/**
-	 * Fetch sessions data from GA4
-	 *
-	 * @param string $start_date Start date
-	 * @param string $end_date   End date
-	 * @return string Sessions count
-	 */
-	private function fetch_sessions( string $start_date, string $end_date ): string {
-		// For demo purposes, return mock data
-		// In production, this would make an actual API call
-		return $this->make_api_request( 'sessions', $start_date, $end_date );
+        /**
+         * Fetch sessions data from GA4
+         *
+         * @param string $start_date Start date
+         * @param string $end_date   End date
+         * @return string Sessions count
+         */
+        private function fetch_sessions( string $start_date, string $end_date ): string {
+                return $this->make_api_request( 'sessions', $start_date, $end_date );
 	}
 
 	/**
@@ -188,26 +191,159 @@ class GoogleAnalytics4 {
 		return $this->make_api_request( 'totalRevenue', $start_date, $end_date );
 	}
 
-	/**
-	 * Make API request to GA4 (mock implementation for demo)
-	 *
-	 * @param string $metric     Metric name
-	 * @param string $start_date Start date
-	 * @param string $end_date   End date
-	 * @return string Metric value
-	 */
-	private function make_api_request( string $metric, string $start_date, string $end_date ): string {
-		// Mock implementation for demo purposes
-		// In production, this would make actual API calls to GA4
-		$mock_data = [
-			'sessions' => (string) rand( 1000, 5000 ),
-			'totalUsers' => (string) rand( 800, 4000 ),
-			'conversions' => (string) rand( 10, 100 ),
-			'totalRevenue' => (string) rand( 1000, 10000 ),
-		];
+        /**
+         * Make API request to GA4 using the Data API
+         *
+         * @param string $metric     Metric name
+         * @param string $start_date Start date
+         * @param string $end_date   End date
+         * @param bool   $retry_on_unauthorized Whether we should attempt a token refresh on 401 responses.
+         * @return string Metric value
+         */
+        private function make_api_request( string $metric, string $start_date, string $end_date, bool $retry_on_unauthorized = true ): string {
+                if ( ! $this->has_oauth_client() || '' === $this->property_id ) {
+                        return '0';
+                }
 
-		return $mock_data[ $metric ] ?? '0';
-	}
+                if ( ! function_exists( 'wp_remote_post' ) || ! function_exists( 'wp_remote_retrieve_body' ) || ! function_exists( 'wp_remote_retrieve_response_code' ) ) {
+                        // We're likely running in a non-WordPress context (e.g., unit tests)
+                        return '0';
+                }
+
+                $access_token = $this->oauth_client->get_access_token();
+
+                if ( ! is_string( $access_token ) || '' === $access_token ) {
+                        if ( ! $this->oauth_client->refresh_token_if_needed() ) {
+                                $this->log_api_error( 'Missing GA4 access token', [ 'metric' => $metric ] );
+                                return '0';
+                        }
+
+                        $access_token = $this->oauth_client->get_access_token();
+
+                        if ( ! is_string( $access_token ) || '' === $access_token ) {
+                                $this->log_api_error( 'Failed to obtain GA4 access token after refresh', [ 'metric' => $metric ] );
+                                return '0';
+                        }
+                }
+
+                $payload = [
+                        'dateRanges' => [
+                                [
+                                        'startDate' => $start_date,
+                                        'endDate'   => $end_date,
+                                ],
+                        ],
+                        'metrics' => [
+                                [
+                                        'name' => $metric,
+                                ],
+                        ],
+                ];
+
+                $encoded_payload = wp_json_encode( $payload );
+
+                if ( ! is_string( $encoded_payload ) ) {
+                        $this->log_api_error( 'Failed to encode GA4 API payload', [ 'metric' => $metric ] );
+                        return '0';
+                }
+
+                $url = sprintf(
+                        '%s/properties/%s:runReport',
+                        self::API_BASE_URL,
+                        rawurlencode( $this->property_id )
+                );
+
+                $response = wp_remote_post(
+                        $url,
+                        [
+                                'timeout' => 20,
+                                'headers' => [
+                                        'Authorization' => 'Bearer ' . $access_token,
+                                        'Content-Type'  => 'application/json',
+                                ],
+                                'body'    => $encoded_payload,
+                        ]
+                );
+
+                if ( function_exists( 'is_wp_error' ) && is_wp_error( $response ) ) {
+                        $this->log_api_error(
+                                'GA4 API request failed',
+                                [
+                                        'metric' => $metric,
+                                        'error'  => $response->get_error_message(),
+                                ]
+                        );
+                        return '0';
+                }
+
+                $status_code = (int) wp_remote_retrieve_response_code( $response );
+
+                if ( 401 === $status_code && $retry_on_unauthorized ) {
+                        if ( $this->oauth_client->refresh_token_if_needed() ) {
+                                return $this->make_api_request( $metric, $start_date, $end_date, false );
+                        }
+
+                        $this->log_api_error( 'GA4 token refresh failed after unauthorized response', [ 'metric' => $metric ] );
+                        return '0';
+                }
+
+                $body = wp_remote_retrieve_body( $response );
+
+                if ( 200 !== $status_code ) {
+                        $this->log_api_error(
+                                'Unexpected GA4 API status code',
+                                [
+                                        'metric' => $metric,
+                                        'status' => $status_code,
+                                ]
+                        );
+                        return '0';
+                }
+
+                $data = json_decode( $body, true );
+
+                if ( ! is_array( $data ) ) {
+                        $this->log_api_error( 'GA4 API returned invalid JSON', [ 'metric' => $metric ] );
+                        return '0';
+                }
+
+                if ( empty( $data['rows'][0]['metricValues'][0]['value'] ) ) {
+                        return '0';
+                }
+
+                $value = (string) $data['rows'][0]['metricValues'][0]['value'];
+
+                // Ensure numeric strings use a consistent format.
+                if ( is_numeric( $value ) ) {
+                        $value = (string) ( 0 + $value );
+                }
+
+                return $value;
+        }
+
+        /**
+         * Log GA4 API errors when debugging is enabled
+         *
+         * @param string               $message Message to log.
+         * @param array<string, mixed> $context Additional context data.
+         * @return void
+         */
+        private function log_api_error( string $message, array $context = [] ): void {
+                if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG || ! function_exists( 'error_log' ) ) {
+                        return;
+                }
+
+                $context_output = '';
+
+                if ( ! empty( $context ) ) {
+                        $encoded_context = function_exists( 'wp_json_encode' ) ? wp_json_encode( $context ) : json_encode( $context );
+                        if ( is_string( $encoded_context ) ) {
+                                $context_output = ' ' . $encoded_context;
+                        }
+                }
+
+                error_log( 'FP Digital Marketing GA4: ' . $message . $context_output );
+        }
 
 	/**
 	 * Store metrics in the cache


### PR DESCRIPTION
## Summary
- replace the mock GA4 metric generation with a real request to the Google Analytics Data API using stored OAuth tokens
- add resilience around token refresh, payload encoding and error logging to ensure production safety when contacting the GA4 endpoint
- keep unit test contexts safe by short-circuiting when WordPress HTTP helpers are unavailable

## Testing
- `composer test` *(fails: phpunit: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d50462bcfc832f8005468af55ac3a7