### PR TITLE
Improve Site Health database diagnostics

### DIFF
--- a/src/Database/ConversionEventsTable.php
+++ b/src/Database/ConversionEventsTable.php
@@ -61,7 +61,13 @@ class ConversionEventsTable {
 	 */
         public static function create_table(): bool {
                 if ( self::using_option_storage() ) {
-                        update_option( self::OPTION_KEY, [], false );
+                        // Ensure the option storage bucket exists so that site health checks
+                        // can verify the "table" availability even before any conversion
+                        // has been recorded.
+                        if ( null === get_option( self::OPTION_KEY, null ) ) {
+                                update_option( self::OPTION_KEY, [], false );
+                        }
+
                         return true;
                 }
 
@@ -117,18 +123,65 @@ class ConversionEventsTable {
         public static function table_exists(): bool {
                 if ( self::using_option_storage() ) {
                         $records = get_option( self::OPTION_KEY, null );
+
+                        if ( null === $records ) {
+                                update_option( self::OPTION_KEY, [], false );
+                                $records = [];
+                        }
+
                         return is_array( $records );
                 }
 
-		global $wpdb;
-		$table_name = self::get_table_name();
+                global $wpdb;
+                $table_name = self::get_table_name();
 
-		if ( ! method_exists( $wpdb, 'prepare' ) || ! method_exists( $wpdb, 'get_var' ) ) {
-			return false;
-		}
+                if ( ! method_exists( $wpdb, 'prepare' ) || ! method_exists( $wpdb, 'get_var' ) ) {
+                        return false;
+                }
 
-		$result = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
-		return $result === $table_name;
+                $result = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+                return $result === $table_name;
+        }
+
+        /**
+         * Determine if the physical database table exists regardless of fallback mode.
+         *
+         * The plugin can fall back to option storage in limited environments, but the
+         * Site Health checks should still verify the original database table so that
+         * administrators can address missing schema issues.
+         *
+         * @return bool True when the physical table is present.
+         */
+        public static function database_table_exists(): bool {
+                global $wpdb;
+
+                if ( ! is_object( $wpdb ) || ! method_exists( $wpdb, 'prepare' ) || ! method_exists( $wpdb, 'get_var' ) ) {
+                        return false;
+                }
+
+                $table_name = self::get_table_name();
+                $result     = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) );
+
+                return $result === $table_name;
+        }
+
+        /**
+         * Provide a human readable storage identifier for health checks and diagnostics.
+         *
+         * When the plugin cannot rely on a proper wpdb instance it stores conversion
+         * events inside the options table. Site health checks need to reference the
+         * correct storage backend to avoid reporting false positives.
+         *
+         * @return string Storage identifier (table name or option key).
+         */
+        public static function get_storage_identifier(): string {
+                $table_name = self::get_table_name();
+
+                if ( self::using_option_storage() ) {
+                        return $table_name . ' (option storage)';
+                }
+
+                return $table_name;
         }
 
 	/**

--- a/src/Helpers/SiteHealth.php
+++ b/src/Helpers/SiteHealth.php
@@ -75,51 +75,114 @@ class SiteHealth {
                 $missing_tables = [];
 
                 $table_checks = [
-                        'metrics_cache' => static function(): bool {
-                                return class_exists( MetricsCacheTable::class ) && MetricsCacheTable::table_exists();
-                        },
-                        'conversion_events' => static function(): bool {
-                                return class_exists( ConversionEventsTable::class ) && ConversionEventsTable::table_exists();
-                        },
-                        'audience_segments' => static function(): bool {
-                                return class_exists( AudienceSegmentTable::class ) && AudienceSegmentTable::segments_table_exists();
-                        },
-                        'audience_membership' => static function(): bool {
-                                return class_exists( AudienceSegmentTable::class ) && AudienceSegmentTable::membership_table_exists();
-                        },
-                        'utm_campaigns' => static function(): bool {
-                                return class_exists( UTMCampaignsTable::class ) && UTMCampaignsTable::table_exists();
-                        },
-                        'funnels' => static function(): bool {
-                                return class_exists( FunnelTable::class ) && FunnelTable::table_exists() && FunnelTable::stages_table_exists();
-                        },
-                        'customer_journeys' => static function(): bool {
-                                return class_exists( CustomerJourneyTable::class ) && CustomerJourneyTable::table_exists() && CustomerJourneyTable::sessions_table_exists();
-                        },
-                        'custom_reports' => static function(): bool {
-                                return class_exists( CustomReportsTable::class ) && CustomReportsTable::table_exists();
-                        },
-                        'social_sentiment' => static function(): bool {
-                                return class_exists( SocialSentimentTable::class ) && SocialSentimentTable::table_exists();
-                        },
-                        'alert_rules' => static function(): bool {
-                                return class_exists( AlertRulesTable::class ) && AlertRulesTable::table_exists();
-                        },
-                        'anomaly_rules' => static function(): bool {
-                                return class_exists( AnomalyRulesTable::class ) && AnomalyRulesTable::table_exists();
-                        },
-                        'detected_anomalies' => static function(): bool {
-                                return class_exists( DetectedAnomaliesTable::class ) && DetectedAnomaliesTable::table_exists();
-                        },
+                        [
+                                'identifier' => class_exists( MetricsCacheTable::class ) ? MetricsCacheTable::get_table_name() : 'fp_metrics_cache',
+                                'callback'   => static function(): bool {
+                                        return class_exists( MetricsCacheTable::class ) && MetricsCacheTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( ConversionEventsTable::class ) ? ConversionEventsTable::get_storage_identifier() : 'fp_conversion_events',
+                                'callback'   => static function(): bool {
+                                        if ( ! class_exists( ConversionEventsTable::class ) ) {
+                                                return false;
+                                        }
+
+                                        if ( ConversionEventsTable::is_using_option_storage() ) {
+                                                return ConversionEventsTable::database_table_exists();
+                                        }
+
+                                        return ConversionEventsTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( AudienceSegmentTable::class ) ? AudienceSegmentTable::get_segments_table_name() : 'fp_audience_segments',
+                                'callback'   => static function(): bool {
+                                        return class_exists( AudienceSegmentTable::class ) && AudienceSegmentTable::segments_table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( AudienceSegmentTable::class ) ? AudienceSegmentTable::get_membership_table_name() : 'fp_segment_membership',
+                                'callback'   => static function(): bool {
+                                        return class_exists( AudienceSegmentTable::class ) && AudienceSegmentTable::membership_table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( UTMCampaignsTable::class ) ? UTMCampaignsTable::get_table_name() : 'fp_utm_campaigns',
+                                'callback'   => static function(): bool {
+                                        return class_exists( UTMCampaignsTable::class ) && UTMCampaignsTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( FunnelTable::class ) ? FunnelTable::get_table_name() : 'fp_dms_funnels',
+                                'callback'   => static function(): bool {
+                                        return class_exists( FunnelTable::class ) && FunnelTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( FunnelTable::class ) ? FunnelTable::get_stages_table_name() : 'fp_dms_funnel_stages',
+                                'callback'   => static function(): bool {
+                                        return class_exists( FunnelTable::class ) && FunnelTable::stages_table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( CustomerJourneyTable::class ) ? CustomerJourneyTable::get_table_name() : 'fp_dms_customer_journeys',
+                                'callback'   => static function(): bool {
+                                        return class_exists( CustomerJourneyTable::class ) && CustomerJourneyTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( CustomerJourneyTable::class ) ? CustomerJourneyTable::get_sessions_table_name() : 'fp_dms_journey_sessions',
+                                'callback'   => static function(): bool {
+                                        return class_exists( CustomerJourneyTable::class ) && CustomerJourneyTable::sessions_table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( CustomReportsTable::class ) ? CustomReportsTable::get_table_name() : 'fp_dms_custom_reports',
+                                'callback'   => static function(): bool {
+                                        return class_exists( CustomReportsTable::class ) && CustomReportsTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( SocialSentimentTable::class ) ? SocialSentimentTable::get_table_name() : 'fp_dms_social_sentiment',
+                                'callback'   => static function(): bool {
+                                        return class_exists( SocialSentimentTable::class ) && SocialSentimentTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( AlertRulesTable::class ) ? AlertRulesTable::get_table_name() : 'fp_alert_rules',
+                                'callback'   => static function(): bool {
+                                        return class_exists( AlertRulesTable::class ) && AlertRulesTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( AnomalyRulesTable::class ) ? AnomalyRulesTable::get_table_name() : 'fp_anomaly_rules',
+                                'callback'   => static function(): bool {
+                                        return class_exists( AnomalyRulesTable::class ) && AnomalyRulesTable::table_exists();
+                                },
+                        ],
+                        [
+                                'identifier' => class_exists( DetectedAnomaliesTable::class ) ? DetectedAnomaliesTable::get_table_name() : 'fp_detected_anomalies',
+                                'callback'   => static function(): bool {
+                                        return class_exists( DetectedAnomaliesTable::class ) && DetectedAnomaliesTable::table_exists();
+                                },
+                        ],
                 ];
 
-                foreach ( $table_checks as $name => $callback ) {
+                foreach ( $table_checks as $table_check ) {
+                        $identifier = (string) ( $table_check['identifier'] ?? '' );
+                        $callback   = $table_check['callback'] ?? null;
+
+                        if ( '' === $identifier || ! is_callable( $callback ) ) {
+                                continue;
+                        }
+
                         try {
                                 if ( ! $callback() ) {
-                                        $missing_tables[] = $name;
+                                        $missing_tables[] = $identifier;
                                 }
                         } catch ( \Throwable $error ) {
-                                $missing_tables[] = $name;
+                                $missing_tables[] = $identifier;
                         }
                 }
 


### PR DESCRIPTION
## Summary
- ensure the conversion events fallback storage is initialised and expose helpers to inspect the physical table when needed
- update the Site Health database check to list concrete table names and use the new conversion event diagnostics so missing schemas are reported accurately

## Testing
- ./vendor/bin/phpunit --filter SiteHealthTest

------
https://chatgpt.com/codex/tasks/task_e_68d532d561d8832fa139ede6af7c26e8