### PR TITLE
Fix release upload step indentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,15 +155,15 @@ jobs:
           build-info.md
         retention-days: 30
     
-      - name: Upload to releases (if tagged)
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            ${{ steps.build_zip.outputs.zip-path }}
-            ${{ steps.build_zip.outputs.checksum-path }}
-            build-info.md
-          body_path: build-info.md
+    - name: Upload to releases (if tagged)
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ${{ steps.build_zip.outputs.zip-path }}
+          ${{ steps.build_zip.outputs.checksum-path }}
+          build-info.md
+        body_path: build-info.md
         name: FP Digital Marketing Suite v${{ steps.version.outputs.version }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fix the indentation of the release upload step so it is treated as a separate workflow step
- ensure the GitHub release inputs are grouped correctly under the upload-to-releases step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d553288b1c832fbdad3725bc9ac02a