### PR TITLE
Finalize overview dashboard polish

### DIFF
--- a/.overview-state.json
+++ b/.overview-state.json
@@ -1,0 +1,6 @@
+{
+  "task": "overview_page",
+  "current_phase": 7,
+  "done": [1, 2, 3, 4, 5, 6, 7],
+  "progress": 100
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ FP Digital Marketing Suite is a private WordPress plugin to automate marketing p
 - REST API + WP-CLI command coverage
 - QA Automation suite (seed/run/anomalies/status/cleanup via Admin or REST)
 - GitHub Actions workflow for source/release ZIPs, checksums, and tagged releases
+- Client Overview dashboard for real-time KPI snapshots, anomalies, connector health, and quick remediation actions
+
+## Client Overview Dashboard
+The **FP Suite → Overview** page surfaces real-time KPI cards, inline sparklines, anomaly snapshots, datasource health, and job controls per client without waiting for PDF reports. Filters support date presets and custom ranges, auto-refresh can be toggled per user, and responses are cached briefly to stay responsive. REST endpoints under `/wp-json/fpdms/v1/overview/*` power the UI so data can also be consumed programmatically.
 
 ## Installation
 1. Place the plugin folder under `wp-content/plugins/`.

--- a/src/Admin/Menu.php
+++ b/src/Admin/Menu.php
@@ -10,6 +10,7 @@ use FP\DMS\Admin\Pages\DashboardPage;
 use FP\DMS\Admin\Pages\DataSourcesPage;
 use FP\DMS\Admin\Pages\HealthPage;
 use FP\DMS\Admin\Pages\LogsPage;
+use FP\DMS\Admin\Pages\OverviewPage;
 use FP\DMS\Admin\Pages\SchedulesPage;
 use FP\DMS\Admin\Pages\SettingsPage;
 use FP\DMS\Admin\Pages\TemplatesPage;
@@ -39,6 +40,7 @@ class Menu
         );
 
         add_submenu_page('fp-dms-dashboard', __('Dashboard', 'fp-dms'), __('Dashboard', 'fp-dms'), 'manage_options', 'fp-dms-dashboard', [DashboardPage::class, 'render']);
+        add_submenu_page('fp-dms-dashboard', __('Overview', 'fp-dms'), __('Overview', 'fp-dms'), 'manage_options', 'fp-dms-overview', [OverviewPage::class, 'render']);
         add_submenu_page('fp-dms-dashboard', __('Clients', 'fp-dms'), __('Clients', 'fp-dms'), 'manage_options', 'fp-dms-clients', [ClientsPage::class, 'render']);
         add_submenu_page('fp-dms-dashboard', __('Data Sources', 'fp-dms'), __('Data Sources', 'fp-dms'), 'manage_options', 'fp-dms-datasources', [DataSourcesPage::class, 'render']);
         add_submenu_page('fp-dms-dashboard', __('Schedules', 'fp-dms'), __('Schedules', 'fp-dms'), 'manage_options', 'fp-dms-schedules', [SchedulesPage::class, 'render']);

--- a/src/Admin/Pages/OverviewPage.php
+++ b/src/Admin/Pages/OverviewPage.php
@@ -1,0 +1,1209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Admin\Pages;
+
+use FP\DMS\Domain\Repos\ClientsRepo;
+use FP\DMS\Support\UserPrefs;
+
+use function add_query_arg;
+use function admin_url;
+use function array_map;
+use function current_user_can;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function esc_url;
+use function esc_url_raw;
+use function rest_url;
+use function wp_create_nonce;
+use function wp_json_encode;
+
+class OverviewPage
+{
+    /**
+     * @var array<string, string>
+     */
+    private const KPI_LABELS = [
+        'users' => 'Users',
+        'sessions' => 'Sessions',
+        'clicks' => 'Clicks',
+        'impressions' => 'Impressions',
+        'cost' => 'Cost',
+        'conversions' => 'Conversions',
+        'revenue' => 'Revenue',
+        'gsc_clicks' => 'GSC Clicks',
+        'gsc_impressions' => 'GSC Impressions',
+    ];
+
+    /**
+     * @var string[]
+     */
+    private const TREND_METRICS = ['users', 'sessions', 'clicks', 'conversions'];
+
+    /**
+     * @var int[]
+     */
+    private const REFRESH_INTERVALS = [60, 120];
+
+    public static function render(): void
+    {
+        if (! current_user_can('manage_options')) {
+            return;
+        }
+
+        $clients = self::clientOptions();
+
+        echo '<div class="wrap fpdms-overview-wrap" id="fpdms-overview-root">';
+        echo '<h1>' . esc_html__('Overview', 'fp-dms') . '</h1>';
+
+        if (empty($clients)) {
+            echo '<p>' . esc_html__('No clients available yet. Add a client to view the dashboard.', 'fp-dms') . '</p>';
+            echo '<p>';
+            echo '<a class="button button-primary" href="' . esc_url(add_query_arg(['page' => 'fp-dms-clients'], admin_url('admin.php'))) . '">';
+            echo esc_html__('Add your first client', 'fp-dms');
+            echo '</a>';
+            echo '</p>';
+            echo '</div>';
+
+            return;
+        }
+
+        self::renderStyles();
+        self::renderErrorBanner();
+        self::renderFilters($clients);
+        self::renderSummarySection();
+        self::renderTrendSection();
+        self::renderAnomaliesSection();
+        self::renderStatusSection();
+        self::renderJobsSection();
+        self::renderConfig($clients);
+        self::renderScript();
+
+        echo '</div>';
+    }
+
+    /**
+     * @return array<int, array{id: int, name: string}>
+     */
+    private static function clientOptions(): array
+    {
+        $repo = new ClientsRepo();
+        $clients = $repo->all();
+
+        return array_map(
+            static fn(\FP\DMS\Domain\Entities\Client $client): array => [
+                'id' => (int) ($client->id ?? 0),
+                'name' => $client->name,
+            ],
+            $clients
+        );
+    }
+
+    private static function renderStyles(): void
+    {
+        echo '<style id="fpdms-overview-styles">';
+        echo '.fpdms-overview-wrap{max-width:1200px;}';
+        echo '.fpdms-overview-wrap.is-loading{opacity:.6;}';
+        echo '.fpdms-overview-controls{display:flex;flex-wrap:wrap;gap:16px;margin-bottom:20px;padding:16px;background:#fff;border:1px solid #ccd0d4;border-radius:6px;}';
+        echo '.fpdms-overview-field{display:flex;flex-direction:column;gap:6px;min-width:200px;}';
+        echo '.fpdms-overview-field select{min-width:220px;}';
+        echo '.fpdms-overview-presets{display:flex;flex-wrap:wrap;gap:8px;}';
+        echo '.fpdms-overview-presets button{background:#f6f7f7;border:1px solid #ccd0d4;border-radius:4px;padding:4px 10px;cursor:pointer;}';
+        echo '.fpdms-overview-presets button.is-active{background:#2271b1;border-color:#2271b1;color:#fff;}';
+        echo '.fpdms-overview-custom{display:flex;gap:12px;align-items:flex-end;}';
+        echo '.fpdms-overview-refresh{display:flex;flex-direction:column;gap:6px;min-width:200px;}';
+        echo '.fpdms-overview-refresh label{display:flex;align-items:center;gap:8px;font-size:13px;font-weight:600;color:#1f2933;}';
+        echo '.fpdms-overview-refresh select{min-width:160px;}';
+        echo '.fpdms-overview-refresh-note{font-size:12px;color:#6b7280;}';
+        echo '.fpdms-overview-custom label{display:flex;flex-direction:column;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:#4b5563;}';
+        echo '.fpdms-overview-section{margin-bottom:24px;background:#fff;border:1px solid #ccd0d4;border-radius:6px;padding:16px;}';
+        echo '.fpdms-overview-section header{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;margin-bottom:12px;gap:8px;}';
+        echo '.fpdms-overview-section h2{font-size:18px;margin:0;}';
+        echo '.fpdms-overview-period{font-size:13px;color:#4b5563;}';
+        echo '#fpdms-overview-status-updated{display:block;font-size:12px;color:#6b7280;}';
+        echo '.fpdms-overview-kpis{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:16px;}';
+        echo '.fpdms-kpi-card{border:1px solid #d5d8dc;border-radius:6px;padding:12px;display:flex;flex-direction:column;gap:8px;min-height:150px;background:#fdfdfd;}';
+        echo '.fpdms-kpi-label{font-size:13px;font-weight:600;color:#1f2933;}';
+        echo '.fpdms-kpi-value{font-size:28px;font-weight:700;color:#111827;}';
+        echo '.fpdms-kpi-delta{font-size:13px;display:flex;align-items:center;gap:6px;}';
+        echo '.fpdms-kpi-delta span{padding:2px 6px;border-radius:999px;font-weight:600;}';
+        echo '.fpdms-kpi-delta span[data-direction="up"]{background:#e6f4ea;color:#116149;}';
+        echo '.fpdms-kpi-delta span[data-direction="down"]{background:#fde8e8;color:#9b1c1c;}';
+        echo '.fpdms-kpi-delta span[data-direction="flat"]{background:#e4e7eb;color:#273444;}';
+        echo '.fpdms-kpi-previous{font-size:12px;color:#6b7280;}';
+        echo '.fpdms-kpi-sparkline{width:100%;height:48px;}';
+        echo '.fpdms-kpi-sparkline svg{width:100%;height:100%;}';
+        echo '.fpdms-overview-trends{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:16px;}';
+        echo '.fpdms-trend-card{border:1px solid #d5d8dc;border-radius:6px;padding:12px;background:#fdfdfd;}';
+        echo '.fpdms-trend-card h3{margin:0 0 8px;font-size:15px;}';
+        echo '.fpdms-trend-card svg{width:100%;height:80px;}';
+        echo '.fpdms-anomalies-table{width:100%;border-collapse:collapse;}';
+        echo '.fpdms-anomalies-table th,.fpdms-anomalies-table td{border-bottom:1px solid #e5e7eb;padding:8px;text-align:left;}';
+        echo '.fpdms-anomaly-badge{display:inline-flex;align-items:center;padding:2px 6px;border-radius:999px;font-size:12px;font-weight:600;}';
+        echo '.fpdms-anomaly-badge[data-variant="critical"]{background:#fde8e8;color:#9b1c1c;}';
+        echo '.fpdms-anomaly-badge[data-variant="warning"]{background:#fff4ce;color:#924400;}';
+        echo '.fpdms-anomaly-badge[data-variant="info"]{background:#e0f2ff;color:#0b69a3;}';
+        echo '.fpdms-anomaly-badge[data-variant="neutral"]{background:#e4e7eb;color:#273444;}';
+        echo '.fpdms-status-list{display:grid;grid-template-columns:repeat(auto-fill,minmax(200px,1fr));gap:12px;}';
+        echo '.fpdms-status-item{border:1px solid #d5d8dc;border-radius:6px;padding:12px;background:#fdfdfd;display:flex;flex-direction:column;gap:6px;}';
+        echo '.fpdms-status-state{font-weight:700;}';
+        echo '.fpdms-status-state[data-state="ok"]{color:#116149;}';
+        echo '.fpdms-status-state[data-state="warning"]{color:#924400;}';
+        echo '.fpdms-status-state[data-state="missing"]{color:#9b1c1c;}';
+        echo '.fpdms-jobs-placeholder{font-size:13px;color:#4b5563;}';
+        echo '.fpdms-overview-actions{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin-top:12px;}';
+        echo '.fpdms-overview-actions .button{display:inline-flex;align-items:center;gap:6px;}';
+        echo '.fpdms-overview-actions .button.is-busy{opacity:.6;pointer-events:none;}';
+        echo '.fpdms-overview-action-status{min-height:20px;font-size:12px;color:#2563eb;transition:opacity .2s ease;opacity:0;}';
+        echo '.fpdms-overview-action-status[data-status="success"]{color:#116149;}';
+        echo '.fpdms-overview-action-status[data-status="error"]{color:#9b1c1c;}';
+        echo '.fpdms-overview-action-status[data-status="info"]{color:#2563eb;}';
+        echo '.fpdms-overview-action-status.is-visible{opacity:1;}';
+        echo '.fpdms-overview-error{display:none;margin:0 0 16px;padding:12px;border-left:4px solid #d63638;background:#f8d7da;color:#58151c;border-radius:4px;}';
+        echo '.fpdms-overview-error.is-visible{display:block;}';
+        echo '.fpdms-overview-spinner{display:none;margin-left:8px;}';
+        echo '.fpdms-overview-wrap.is-loading .fpdms-overview-spinner{display:inline-block;animation:fpdms-spin 1s linear infinite;}';
+        echo '@keyframes fpdms-spin{from{transform:rotate(0);}to{transform:rotate(360deg);}}';
+        echo '@media (prefers-color-scheme:dark){';
+        echo '.fpdms-overview-wrap{color:#e5e7eb;}';
+        echo '.fpdms-overview-controls,.fpdms-overview-section{background:#111827;border-color:#1f2937;}';
+        echo '.fpdms-kpi-card,.fpdms-trend-card,.fpdms-status-item{background:#1f2937;border-color:#374151;}';
+        echo '.fpdms-overview-presets button{background:#1f2937;border-color:#374151;color:#e5e7eb;}';
+        echo '.fpdms-overview-presets button.is-active{background:#2563eb;border-color:#2563eb;color:#fff;}';
+        echo '.fpdms-overview-refresh label{color:#e5e7eb;}';
+        echo '.fpdms-overview-refresh-note{color:#9ca3af;}';
+        echo '#fpdms-overview-status-updated{color:#9ca3af;}';
+        echo '.fpdms-overview-error{background:#7f1d1d;color:#fee2e2;}';
+        echo '.fpdms-overview-action-status{color:#60a5fa;}';
+        echo '.fpdms-overview-action-status[data-status="success"]{color:#6ee7b7;}';
+        echo '.fpdms-overview-action-status[data-status="error"]{color:#fca5a5;}';
+        echo '}' ;
+        echo '</style>';
+    }
+
+    private static function renderErrorBanner(): void
+    {
+        echo '<div id="fpdms-overview-error" class="fpdms-overview-error" role="alert">';
+        echo '<strong>' . esc_html__('Unable to load overview data.', 'fp-dms') . '</strong> ';
+        echo '<span id="fpdms-overview-error-message">' . esc_html__('Retry in a moment.', 'fp-dms') . '</span>';
+        echo '</div>';
+    }
+
+    /**
+     * @param array<int, array{id: int, name: string}> $clients
+     */
+    private static function renderFilters(array $clients): void
+    {
+        $presets = [
+            'last7' => esc_html__('Last 7 days', 'fp-dms'),
+            'last14' => esc_html__('Last 14 days', 'fp-dms'),
+            'last28' => esc_html__('Last 28 days', 'fp-dms'),
+            'this_month' => esc_html__('This month', 'fp-dms'),
+            'last_month' => esc_html__('Last month', 'fp-dms'),
+            'custom' => esc_html__('Custom', 'fp-dms'),
+        ];
+
+        echo '<div class="fpdms-overview-controls" role="region" aria-label="' . esc_attr__('Overview filters', 'fp-dms') . '">';
+
+        echo '<div class="fpdms-overview-field">';
+        echo '<label for="fpdms-overview-client">' . esc_html__('Client', 'fp-dms') . '</label>';
+        echo '<select id="fpdms-overview-client">';
+        foreach ($clients as $client) {
+            echo '<option value="' . esc_attr((string) $client['id']) . '">' . esc_html($client['name']) . '</option>';
+        }
+        echo '</select>';
+        echo '</div>';
+
+        echo '<div class="fpdms-overview-field" style="flex:1;min-width:260px;">';
+        echo '<span class="fpdms-label">' . esc_html__('Date range', 'fp-dms') . '</span>';
+        echo '<div class="fpdms-overview-presets" role="group" aria-label="' . esc_attr__('Date presets', 'fp-dms') . '">';
+        foreach ($presets as $key => $label) {
+            echo '<button type="button" data-fpdms-preset="' . esc_attr($key) . '" aria-pressed="false">' . $label . '</button>';
+        }
+        echo '</div>';
+        echo '<div class="fpdms-overview-custom" id="fpdms-overview-custom" hidden>';
+        echo '<label>' . esc_html__('From', 'fp-dms') . '<input type="date" id="fpdms-overview-date-from"></label>';
+        echo '<label>' . esc_html__('To', 'fp-dms') . '<input type="date" id="fpdms-overview-date-to"></label>';
+        echo '</div>';
+        echo '</div>';
+
+        echo '<div class="fpdms-overview-refresh" aria-live="polite">';
+        echo '<label for="fpdms-overview-refresh-toggle">';
+        echo '<input type="checkbox" id="fpdms-overview-refresh-toggle">';
+        echo '<span>' . esc_html__('Auto-refresh', 'fp-dms') . '</span>';
+        echo '</label>';
+        echo '<select id="fpdms-overview-refresh-interval" aria-label="' . esc_attr__('Auto-refresh interval', 'fp-dms') . '">';
+        foreach (self::REFRESH_INTERVALS as $seconds) {
+            echo '<option value="' . esc_attr((string) $seconds) . '">' . esc_html(sprintf(/* translators: %d is seconds */ __('Every %d seconds', 'fp-dms'), $seconds)) . '</option>';
+        }
+        echo '</select>';
+        echo '<span class="fpdms-overview-refresh-note" id="fpdms-overview-last-refresh">' . esc_html__('Last refresh: never', 'fp-dms') . '</span>';
+        echo '</div>';
+
+        echo '</div>';
+    }
+
+    private static function renderSummarySection(): void
+    {
+        echo '<section class="fpdms-overview-section" aria-labelledby="fpdms-overview-kpis-heading">';
+        echo '<header>';
+        echo '<h2 id="fpdms-overview-kpis-heading">' . esc_html__('Key metrics', 'fp-dms') . '</h2>';
+        echo '<div class="fpdms-overview-period" id="fpdms-overview-period"><span id="fpdms-overview-period-label">' . esc_html__('Loading…', 'fp-dms') . '</span><span class="fpdms-overview-spinner">&#x27F3;</span></div>';
+        echo '</header>';
+        echo '<div class="fpdms-overview-kpis" id="fpdms-overview-kpis" aria-live="polite">';
+        foreach (self::KPI_LABELS as $metric => $label) {
+            self::renderKpiCard($metric, $label);
+        }
+        echo '</div>';
+        echo '</section>';
+    }
+
+    private static function renderTrendSection(): void
+    {
+        echo '<section class="fpdms-overview-section" aria-labelledby="fpdms-overview-trends-heading">';
+        echo '<header>';
+        echo '<h2 id="fpdms-overview-trends-heading">' . esc_html__('Trend snapshots', 'fp-dms') . '</h2>';
+        echo '<span class="fpdms-overview-period" id="fpdms-overview-trend-period">' . esc_html__('Daily values over the selected window.', 'fp-dms') . '</span>';
+        echo '</header>';
+        echo '<div class="fpdms-overview-trends" id="fpdms-overview-trends-grid">';
+        foreach (self::TREND_METRICS as $metric) {
+            $label = self::KPI_LABELS[$metric] ?? $metric;
+            echo '<article class="fpdms-trend-card" data-metric="' . esc_attr($metric) . '">';
+            echo '<h3>' . esc_html__(self::KPI_LABELS[$metric] ?? ucfirst($metric), 'fp-dms') . '</h3>';
+            echo '<svg role="img" aria-label="' . esc_attr(sprintf(esc_html__('%s sparkline', 'fp-dms'), esc_html__(self::KPI_LABELS[$metric] ?? ucfirst($metric), 'fp-dms'))) . '" viewBox="0 0 100 40"></svg>';
+            echo '<p class="fpdms-kpi-previous" data-role="trend-meta">' . esc_html__('Awaiting data…', 'fp-dms') . '</p>';
+            echo '</article>';
+        }
+        echo '</div>';
+        echo '</section>';
+    }
+
+    private static function renderAnomaliesSection(): void
+    {
+        echo '<section class="fpdms-overview-section" aria-labelledby="fpdms-overview-anomalies-heading">';
+        echo '<header>';
+        echo '<h2 id="fpdms-overview-anomalies-heading">' . esc_html__('Recent anomalies', 'fp-dms') . '</h2>';
+        echo '<span class="fpdms-overview-period" id="fpdms-overview-anomalies-meta">' . esc_html__('Last 10 flagged signals.', 'fp-dms') . '</span>';
+        echo '</header>';
+        echo '<div class="fpdms-overview-anomalies">';
+        echo '<table class="fpdms-anomalies-table" id="fpdms-overview-anomalies">';
+        echo '<thead><tr>';
+        echo '<th scope="col">' . esc_html__('Severity', 'fp-dms') . '</th>';
+        echo '<th scope="col">' . esc_html__('Metric', 'fp-dms') . '</th>';
+        echo '<th scope="col">' . esc_html__('Change', 'fp-dms') . '</th>';
+        echo '<th scope="col">' . esc_html__('Score', 'fp-dms') . '</th>';
+        echo '<th scope="col">' . esc_html__('When', 'fp-dms') . '</th>';
+        echo '<th scope="col">' . esc_html__('Actions', 'fp-dms') . '</th>';
+        echo '</tr></thead>';
+        echo '<tbody>';
+        echo '<tr><td colspan="6">' . esc_html__('No anomalies for this range.', 'fp-dms') . '</td></tr>';
+        echo '</tbody>';
+        echo '</table>';
+        echo '</div>';
+        echo '</section>';
+    }
+
+    private static function renderStatusSection(): void
+    {
+        echo '<section class="fpdms-overview-section" aria-labelledby="fpdms-overview-status-heading">';
+        echo '<header>';
+        echo '<h2 id="fpdms-overview-status-heading">' . esc_html__('Data source status', 'fp-dms') . '</h2>';
+        echo '<span class="fpdms-overview-period" id="fpdms-overview-status-meta">' . esc_html__('Connector health at a glance.', 'fp-dms') . '</span>';
+        echo '<span class="fpdms-overview-period" id="fpdms-overview-status-updated" aria-live="polite"></span>';
+        echo '</header>';
+        echo '<div class="fpdms-status-list" id="fpdms-overview-status-list" aria-live="polite">';
+        echo '<div class="fpdms-status-item">';
+        echo '<span class="fpdms-status-label">' . esc_html__('Waiting for data…', 'fp-dms') . '</span>';
+        echo '</div>';
+        echo '</div>';
+        echo '</section>';
+    }
+
+    private static function renderJobsSection(): void
+    {
+        echo '<section class="fpdms-overview-section" aria-labelledby="fpdms-overview-jobs-heading">';
+        echo '<header>';
+        echo '<h2 id="fpdms-overview-jobs-heading">' . esc_html__('Jobs & schedules', 'fp-dms') . '</h2>';
+        echo '<span class="fpdms-overview-period">' . esc_html__('Upcoming runs and recently generated reports.', 'fp-dms') . '</span>';
+        echo '</header>';
+        echo '<p class="fpdms-jobs-placeholder" id="fpdms-overview-jobs">' . esc_html__('Scheduling details will appear here once configured.', 'fp-dms') . '</p>';
+        echo '<div class="fpdms-overview-actions" role="group" aria-label="' . esc_attr__('Quick actions', 'fp-dms') . '">';
+        echo '<button type="button" class="button button-primary" id="fpdms-overview-action-run">' . esc_html__('Run now', 'fp-dms') . '</button>';
+        echo '<button type="button" class="button" id="fpdms-overview-action-anomalies">' . esc_html__('Evaluate anomalies (30 days)', 'fp-dms') . '</button>';
+        echo '<a class="button" href="' . esc_url(add_query_arg(['page' => 'fp-dms-templates'], admin_url('admin.php'))) . '">' . esc_html__('Open templates', 'fp-dms') . '</a>';
+        echo '<span class="fpdms-overview-action-status" id="fpdms-overview-action-status" role="status" aria-live="polite"></span>';
+        echo '</div>';
+        echo '</section>';
+    }
+
+    private static function renderKpiCard(string $metric, string $label): void
+    {
+        echo '<article class="fpdms-kpi-card" data-metric="' . esc_attr($metric) . '">';
+        echo '<div class="fpdms-kpi-label">' . esc_html__($label, 'fp-dms') . '</div>';
+        echo '<div class="fpdms-kpi-value" data-role="value">--</div>';
+        echo '<div class="fpdms-kpi-delta"><span data-role="delta" data-direction="flat">' . esc_html__('0.0%', 'fp-dms') . '</span><span class="fpdms-kpi-previous" data-role="previous">' . esc_html__('Prev: --', 'fp-dms') . '</span></div>';
+        echo '<div class="fpdms-kpi-sparkline"><svg viewBox="0 0 100 40" role="img" aria-label="' . esc_attr(sprintf(esc_html__('%s trend', 'fp-dms'), esc_html__($label, 'fp-dms'))) . '"></svg></div>';
+        echo '</article>';
+    }
+
+    /**
+     * @param array<int, array{id: int, name: string}> $clients
+     */
+    private static function renderConfig(array $clients): void
+    {
+        $preferences = UserPrefs::getOverviewPreferences();
+
+        $config = [
+            'nonce' => wp_create_nonce('wp_rest'),
+            'endpoints' => [
+                'summary' => esc_url_raw(rest_url('fpdms/v1/overview/summary')),
+                'trend' => esc_url_raw(rest_url('fpdms/v1/overview/trend')),
+                'status' => esc_url_raw(rest_url('fpdms/v1/overview/status')),
+                'anomalies' => esc_url_raw(rest_url('fpdms/v1/overview/anomalies')),
+            ],
+            'actions' => [
+                'run' => esc_url_raw(rest_url('fpdms/v1/overview/run')),
+                'anomalies' => esc_url_raw(rest_url('fpdms/v1/overview/anomalies')),
+            ],
+            'clients' => $clients,
+            'kpis' => self::KPI_LABELS,
+            'trendMetrics' => self::TREND_METRICS,
+            'preferences' => $preferences,
+            'refreshIntervals' => self::REFRESH_INTERVALS,
+            'defaultRefreshInterval' => self::REFRESH_INTERVALS[0] ?? 60,
+            'i18n' => [
+                'noData' => esc_html__('No data available.', 'fp-dms'),
+                'loading' => esc_html__('Loading…', 'fp-dms'),
+                'previous' => esc_html__('Previous period', 'fp-dms'),
+                'sparklineFallback' => esc_html__('Trend data will appear soon.', 'fp-dms'),
+                'anomalyAction' => esc_html__('Resolve / Note', 'fp-dms'),
+                'actionError' => esc_html__('Action failed. Try again.', 'fp-dms'),
+                'runPending' => esc_html__('Queuing report…', 'fp-dms'),
+                'runQueued' => esc_html__('Report run queued.', 'fp-dms'),
+                'anomalyRunning' => esc_html__('Evaluating anomalies…', 'fp-dms'),
+                'anomalyComplete' => esc_html__('Anomaly evaluation found %d signals.', 'fp-dms'),
+                'anomalyNone' => esc_html__('No anomalies detected in the last 30 days.', 'fp-dms'),
+                'lastRefresh' => esc_html__('Last refresh at %s', 'fp-dms'),
+                'lastRefreshNever' => esc_html__('Last refresh: never', 'fp-dms'),
+                'autoRefreshInterval' => esc_html__('Auto-refresh interval', 'fp-dms'),
+                'autoRefresh' => esc_html__('Auto-refresh', 'fp-dms'),
+                'refreshing' => esc_html__('Refreshing…', 'fp-dms'),
+                'errorGeneric' => esc_html__('Something went wrong. Please try again.', 'fp-dms'),
+                'statusChecked' => esc_html__('Status checked at %s', 'fp-dms'),
+                'statusUpdated' => esc_html__('Last data update: %s', 'fp-dms'),
+            ],
+        ];
+
+        echo '<script type="application/json" id="fpdms-overview-config">' . wp_json_encode($config) . '</script>';
+    }
+
+    private static function renderScript(): void
+    {
+        echo '<script id="fpdms-overview-script">';
+        ?>
+(function(){
+    const root = document.getElementById('fpdms-overview-root');
+    const configEl = document.getElementById('fpdms-overview-config');
+    if (!root || !configEl) {
+        return;
+    }
+
+    let config = {};
+    try {
+        config = JSON.parse(configEl.textContent || '{}');
+    } catch (error) {
+        console.error('FPDMS overview: invalid config', error);
+        return;
+    }
+
+    const clientSelect = document.getElementById('fpdms-overview-client');
+    const presetButtons = Array.from(document.querySelectorAll('[data-fpdms-preset]'));
+    const presetOptions = presetButtons.map((button) => button.getAttribute('data-fpdms-preset') || '');
+    const customContainer = document.getElementById('fpdms-overview-custom');
+    const dateFrom = document.getElementById('fpdms-overview-date-from');
+    const dateTo = document.getElementById('fpdms-overview-date-to');
+    const periodLabel = document.getElementById('fpdms-overview-period-label');
+    const errorBox = document.getElementById('fpdms-overview-error');
+    const errorMessage = document.getElementById('fpdms-overview-error-message');
+    const summaryContainer = document.getElementById('fpdms-overview-kpis');
+    const trendsContainer = document.getElementById('fpdms-overview-trends-grid');
+    const anomaliesTable = document.querySelector('#fpdms-overview-anomalies tbody');
+    const statusList = document.getElementById('fpdms-overview-status-list');
+    const runButton = document.getElementById('fpdms-overview-action-run');
+    const anomaliesButton = document.getElementById('fpdms-overview-action-anomalies');
+    const actionStatus = document.getElementById('fpdms-overview-action-status');
+    const refreshToggle = document.getElementById('fpdms-overview-refresh-toggle');
+    const refreshSelect = document.getElementById('fpdms-overview-refresh-interval');
+    const lastRefreshNote = document.getElementById('fpdms-overview-last-refresh');
+
+    const refreshIntervals = Array.isArray(config.refreshIntervals)
+        ? config.refreshIntervals
+            .map((interval) => parseInt(interval, 10))
+            .filter((interval) => !Number.isNaN(interval) && interval > 0)
+        : [60, 120];
+
+    const state = {
+        clientId: clientSelect ? clientSelect.value : '',
+        preset: 'last7',
+        customFrom: '',
+        customTo: '',
+        autoRefresh: false,
+        refreshInterval: config.defaultRefreshInterval || 60,
+        lastRefresh: ''
+    };
+
+    let refreshTimer = null;
+
+    function normalizePreset(value) {
+        return presetOptions.includes(value) ? value : 'last7';
+    }
+
+    function clampInterval(value) {
+        const fallback = parseInt(config.defaultRefreshInterval, 10) || refreshIntervals[0] || 60;
+        const seconds = parseInt(value, 10);
+        if (Number.isNaN(seconds) || seconds <= 0) {
+            return fallback;
+        }
+        if (refreshIntervals.includes(seconds)) {
+            return seconds;
+        }
+        const sorted = refreshIntervals.slice().sort((a, b) => Math.abs(a - seconds) - Math.abs(b - seconds));
+        return sorted.length ? sorted[0] : fallback;
+    }
+
+    function formatTimestamp(value) {
+        if (!value) {
+            return '';
+        }
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) {
+            return '';
+        }
+        return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    }
+
+    function resetLastRefreshLabel() {
+        if (!lastRefreshNote) {
+            return;
+        }
+        const formatted = formatTimestamp(state.lastRefresh);
+        if (!formatted) {
+            lastRefreshNote.textContent = config.i18n?.lastRefreshNever || 'Last refresh: never';
+            return;
+        }
+        const template = config.i18n?.lastRefresh || 'Last refresh at %s';
+        lastRefreshNote.textContent = template.replace('%s', formatted);
+    }
+
+    function showRefreshingLabel() {
+        if (!lastRefreshNote) {
+            return;
+        }
+        lastRefreshNote.textContent = config.i18n?.refreshing || 'Refreshing…';
+    }
+
+    function setLastRefresh(timestamp) {
+        state.lastRefresh = timestamp || '';
+        resetLastRefreshLabel();
+    }
+
+    function clearAutoRefreshTimer() {
+        if (refreshTimer) {
+            window.clearTimeout(refreshTimer);
+            refreshTimer = null;
+        }
+    }
+
+    function scheduleAutoRefresh() {
+        clearAutoRefreshTimer();
+        if (!state.autoRefresh) {
+            return;
+        }
+        const interval = clampInterval(state.refreshInterval) * 1000;
+        refreshTimer = window.setTimeout(() => {
+            loadAll(true);
+        }, interval);
+    }
+
+    function formatDate(date) {
+        const pad = (n) => String(n).padStart(2, '0');
+        return date.getFullYear() + '-' + pad(date.getMonth() + 1) + '-' + pad(date.getDate());
+    }
+
+    function computePresetRange(preset) {
+        const today = new Date();
+        let from;
+        let to;
+
+        switch (preset) {
+            case 'last14':
+                to = new Date(today);
+                from = new Date(today);
+                from.setDate(from.getDate() - 13);
+                break;
+            case 'last28':
+                to = new Date(today);
+                from = new Date(today);
+                from.setDate(from.getDate() - 27);
+                break;
+            case 'last30':
+                to = new Date(today);
+                from = new Date(today);
+                from.setDate(from.getDate() - 29);
+                break;
+            case 'this_month': {
+                to = new Date(today);
+                from = new Date(today.getFullYear(), today.getMonth(), 1);
+                break;
+            }
+            case 'last_month': {
+                const firstDayCurrent = new Date(today.getFullYear(), today.getMonth(), 1);
+                to = new Date(firstDayCurrent);
+                to.setDate(0);
+                from = new Date(firstDayCurrent);
+                from.setMonth(from.getMonth() - 1);
+                break;
+            }
+            case 'last7':
+            default:
+                to = new Date(today);
+                from = new Date(today);
+                from.setDate(from.getDate() - 6);
+                break;
+        }
+
+        return {
+            from: from ? formatDate(from) : '',
+            to: to ? formatDate(to) : ''
+        };
+    }
+
+    function computeRange() {
+        if (state.preset === 'custom') {
+            const from = state.customFrom ? new Date(state.customFrom + 'T00:00:00') : null;
+            const to = state.customTo ? new Date(state.customTo + 'T00:00:00') : null;
+
+            return {
+                from: from ? formatDate(from) : '',
+                to: to ? formatDate(to) : ''
+            };
+        }
+
+        return computePresetRange(state.preset);
+    }
+
+    function setPreset(preset, options) {
+        const opts = options || {};
+        const shouldLoad = opts.load !== false;
+        const preserveCustom = !!opts.preserveCustom;
+        state.preset = preset;
+        presetButtons.forEach((button) => {
+            const isActive = button.getAttribute('data-fpdms-preset') === preset;
+            button.classList.toggle('is-active', isActive);
+            button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+        if (customContainer) {
+            customContainer.hidden = preset !== 'custom';
+        }
+        if (preset !== 'custom') {
+            if (!preserveCustom) {
+                state.customFrom = '';
+                state.customTo = '';
+                if (dateFrom) {
+                    dateFrom.value = '';
+                }
+                if (dateTo) {
+                    dateTo.value = '';
+                }
+            }
+            if (shouldLoad) {
+                loadAll();
+            }
+            return;
+        }
+
+        if (dateFrom) {
+            dateFrom.value = state.customFrom || '';
+        }
+        if (dateTo) {
+            dateTo.value = state.customTo || '';
+        }
+
+        if (state.customFrom && state.customTo) {
+            if (shouldLoad) {
+                loadAll();
+            }
+        }
+    }
+
+    function showError(message) {
+        if (!errorBox || !errorMessage) {
+            return;
+        }
+        const fallback = config.i18n?.errorGeneric || 'Error';
+        errorMessage.textContent = message || fallback;
+        errorBox.classList.add('is-visible');
+    }
+
+    function clearError() {
+        if (!errorBox) {
+            return;
+        }
+        errorBox.classList.remove('is-visible');
+    }
+
+    function setActionBusy(button, busy) {
+        if (!button) {
+            return;
+        }
+        button.classList.toggle('is-busy', !!busy);
+        button.disabled = !!busy;
+    }
+
+    function showActionStatus(type, message) {
+        if (!actionStatus) {
+            return;
+        }
+        actionStatus.textContent = message || '';
+        if (!message) {
+            actionStatus.classList.remove('is-visible');
+            actionStatus.removeAttribute('data-status');
+            return;
+        }
+        actionStatus.classList.add('is-visible');
+        actionStatus.setAttribute('data-status', type || 'info');
+    }
+
+    function formatCountMessage(template, count) {
+        if (typeof template !== 'string') {
+            return '';
+        }
+        return template.replace('%d', String(count));
+    }
+
+    function renderSparkline(svg, values) {
+        if (!svg) {
+            return;
+        }
+        while (svg.firstChild) {
+            svg.removeChild(svg.firstChild);
+        }
+        if (!Array.isArray(values) || values.length === 0) {
+            const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+            text.setAttribute('x', '4');
+            text.setAttribute('y', '22');
+            text.setAttribute('fill', '#9ca3af');
+            text.textContent = config.i18n?.sparklineFallback || 'No data';
+            svg.appendChild(text);
+            return;
+        }
+        const max = Math.max.apply(null, values);
+        const min = Math.min.apply(null, values);
+        const range = max - min || 1;
+        const height = 40;
+        const width = 100;
+        const points = values.map((value, index) => {
+            const x = values.length === 1 ? width : (width / (values.length - 1)) * index;
+            const normalized = (value - min) / range;
+            const y = height - (normalized * 32 + 4);
+            return { x, y };
+        });
+        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+        let d = '';
+        points.forEach((point, index) => {
+            d += (index === 0 ? 'M' : 'L') + point.x.toFixed(2) + ' ' + point.y.toFixed(2) + ' ';
+        });
+        path.setAttribute('d', d.trim());
+        path.setAttribute('fill', 'none');
+        path.setAttribute('stroke', '#2563eb');
+        path.setAttribute('stroke-width', '2');
+        svg.appendChild(path);
+    }
+
+    function updateSummary(data) {
+        const summary = data && data.summary ? data.summary : data;
+        if (!summary) {
+            return;
+        }
+        const refreshedAt = summary.refreshed_at || (data && data.refreshed_at);
+        if (refreshedAt) {
+            setLastRefresh(refreshedAt);
+        } else if (!state.lastRefresh) {
+            setLastRefresh(new Date().toISOString());
+        }
+        if (summary.period && periodLabel) {
+            const from = summary.period.from || '';
+            const to = summary.period.to || '';
+            periodLabel.textContent = from && to ? from + ' → ' + to : config.i18n?.loading || '';
+        }
+        if (!summaryContainer || !Array.isArray(summary.kpis)) {
+            return;
+        }
+        const cards = Array.from(summaryContainer.querySelectorAll('.fpdms-kpi-card'));
+        cards.forEach((card) => {
+            const metric = card.getAttribute('data-metric');
+            const kpi = summary.kpis.find((item) => item.metric === metric);
+            const valueEl = card.querySelector('[data-role="value"]');
+            const deltaEl = card.querySelector('[data-role="delta"]');
+            const previousEl = card.querySelector('[data-role="previous"]');
+            const sparklineSvg = card.querySelector('svg');
+            if (!kpi) {
+                if (valueEl) {
+                    valueEl.textContent = '--';
+                }
+                if (deltaEl) {
+                    deltaEl.textContent = '0%';
+                    deltaEl.setAttribute('data-direction', 'flat');
+                }
+                if (previousEl) {
+                    previousEl.textContent = config.i18n?.previous + ': --';
+                }
+                renderSparkline(sparklineSvg, []);
+                return;
+            }
+            if (valueEl) {
+                valueEl.textContent = kpi.formatted_value || String(kpi.value || '--');
+            }
+            if (deltaEl) {
+                const delta = kpi.delta || {};
+                const formatted = delta.formatted || '0%';
+                const direction = delta.direction || 'flat';
+                deltaEl.textContent = formatted;
+                deltaEl.setAttribute('data-direction', direction);
+            }
+            if (previousEl) {
+                const prev = kpi.formatted_previous || String(kpi.previous_value ?? '--');
+                previousEl.textContent = (config.i18n?.previous || 'Previous') + ': ' + prev;
+            }
+            renderSparkline(sparklineSvg, Array.isArray(kpi.sparkline) ? kpi.sparkline : []);
+        });
+        updateTrends(summary);
+    }
+
+    function updateTrends(summary) {
+        if (!trendsContainer || !summary || !Array.isArray(summary.kpis)) {
+            return;
+        }
+        const kpiIndex = {};
+        summary.kpis.forEach((kpi) => {
+            if (kpi && kpi.metric) {
+                kpiIndex[kpi.metric] = kpi;
+            }
+        });
+        Array.from(trendsContainer.querySelectorAll('.fpdms-trend-card')).forEach((card) => {
+            const metric = card.getAttribute('data-metric');
+            const kpi = kpiIndex[metric];
+            const svg = card.querySelector('svg');
+            const meta = card.querySelector('[data-role="trend-meta"]');
+            if (!kpi) {
+                if (meta) {
+                    meta.textContent = config.i18n?.sparklineFallback || 'No data';
+                }
+                renderSparkline(svg, []);
+                return;
+            }
+            if (meta) {
+                meta.textContent = (config.i18n?.previous || 'Previous') + ': ' + (kpi.formatted_previous || '--');
+            }
+            renderSparkline(svg, Array.isArray(kpi.sparkline) ? kpi.sparkline : []);
+        });
+    }
+
+    function updateStatus(data) {
+        if (!statusList) {
+            return;
+        }
+        statusList.innerHTML = '';
+        const statusUpdated = document.getElementById('fpdms-overview-status-updated');
+        if (statusUpdated) {
+            const formatted = data && data.checked_at ? formatTimestamp(data.checked_at) : '';
+            if (formatted) {
+                const template = config.i18n?.statusChecked || 'Status checked at %s';
+                statusUpdated.textContent = template.replace('%s', formatted);
+                statusUpdated.hidden = false;
+            } else {
+                statusUpdated.textContent = '';
+                statusUpdated.hidden = true;
+            }
+        }
+        const entries = data && Array.isArray(data.sources) ? data.sources : (Array.isArray(data) ? data : []);
+        if (!entries.length) {
+            const placeholder = document.createElement('div');
+            placeholder.className = 'fpdms-status-item';
+            placeholder.textContent = config.i18n?.noData || 'No data available.';
+            statusList.appendChild(placeholder);
+            return;
+        }
+        entries.forEach((entry) => {
+            const item = document.createElement('div');
+            item.className = 'fpdms-status-item';
+            const label = document.createElement('span');
+            label.className = 'fpdms-status-label';
+            label.textContent = entry.label || entry.type || '';
+            const state = document.createElement('span');
+            state.className = 'fpdms-status-state';
+            const stateValue = entry.state || 'ok';
+            state.setAttribute('data-state', stateValue);
+            const stateLabel = entry.state_label || (stateValue ? String(stateValue).toUpperCase() : '');
+            state.textContent = stateLabel;
+            const message = document.createElement('span');
+            message.className = 'fpdms-status-message';
+            message.textContent = entry.message || '';
+            const updated = document.createElement('span');
+            updated.className = 'fpdms-status-updated';
+            if (entry.last_updated) {
+                const template = config.i18n?.statusUpdated || 'Last data update: %s';
+                updated.textContent = template.replace('%s', entry.last_updated);
+            }
+            item.appendChild(label);
+            item.appendChild(state);
+            if (entry.message) {
+                item.appendChild(message);
+            }
+            if (entry.last_updated) {
+                item.appendChild(updated);
+            }
+            statusList.appendChild(item);
+        });
+    }
+
+    function updateAnomalies(data) {
+        if (!anomaliesTable) {
+            return;
+        }
+        anomaliesTable.innerHTML = '';
+        const items = data && Array.isArray(data.anomalies) ? data.anomalies : (Array.isArray(data) ? data : []);
+        if (!items.length) {
+            const row = document.createElement('tr');
+            const cell = document.createElement('td');
+            cell.colSpan = 6;
+            cell.textContent = config.i18n?.noData || 'No data available.';
+            row.appendChild(cell);
+            anomaliesTable.appendChild(row);
+            return;
+        }
+        items.slice(0, 10).forEach((item) => {
+            const row = document.createElement('tr');
+            const severity = document.createElement('td');
+            const badge = document.createElement('span');
+            badge.className = 'fpdms-anomaly-badge';
+            const variant = item.severity_variant || item.variant || 'neutral';
+            badge.setAttribute('data-variant', variant);
+            badge.textContent = item.severity_label || item.severity || variant;
+            severity.appendChild(badge);
+            const metric = document.createElement('td');
+            metric.textContent = item.metric_label || item.metric || '';
+            const change = document.createElement('td');
+            change.textContent = item.delta_formatted || item.delta || '';
+            const score = document.createElement('td');
+            score.textContent = item.score !== undefined ? String(item.score) : '';
+            const when = document.createElement('td');
+            when.textContent = item.occurred_at || item.time || '';
+            const actions = document.createElement('td');
+            if (item.url) {
+                const link = document.createElement('a');
+                link.href = item.url;
+                link.textContent = config.i18n?.anomalyAction || 'Resolve / Note';
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+                actions.appendChild(link);
+            } else {
+                actions.textContent = config.i18n?.anomalyAction || 'Resolve / Note';
+            }
+            row.appendChild(severity);
+            row.appendChild(metric);
+            row.appendChild(change);
+            row.appendChild(score);
+            row.appendChild(when);
+            row.appendChild(actions);
+            anomaliesTable.appendChild(row);
+        });
+    }
+
+    function request(url, params) {
+        if (!url) {
+            return Promise.resolve({});
+        }
+        const endpoint = new URL(url, window.location.origin);
+        if (params) {
+            Object.keys(params).forEach((key) => {
+                if (params[key]) {
+                    endpoint.searchParams.set(key, params[key]);
+                }
+            });
+        }
+        return fetch(endpoint.toString(), {
+            credentials: 'same-origin',
+            headers: {
+                'X-WP-Nonce': config.nonce || ''
+            }
+        }).then(async (response) => {
+            if (!response.ok) {
+                const payload = await response.json().catch(() => ({}));
+                const message = payload && payload.message ? payload.message : 'HTTP ' + response.status;
+                throw new Error(message);
+            }
+            return response.json();
+        });
+    }
+
+    function postRequest(url, payload) {
+        if (!url) {
+            return Promise.reject(new Error('Missing endpoint'));
+        }
+
+        return fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-WP-Nonce': config.nonce || ''
+            },
+            body: JSON.stringify(payload || {})
+        }).then(async (response) => {
+            if (!response.ok) {
+                const body = await response.json().catch(() => ({}));
+                const message = body && body.message ? body.message : 'HTTP ' + response.status;
+                throw new Error(message);
+            }
+
+            return response.json();
+        });
+    }
+
+    function loadAll(fromAuto) {
+        if (!state.clientId) {
+            return;
+        }
+        clearError();
+        clearAutoRefreshTimer();
+        const isAuto = !!fromAuto;
+        if (!isAuto) {
+            root.classList.add('is-loading');
+        }
+        showRefreshingLabel();
+        const range = computeRange();
+        const summaryParams = {
+            client_id: state.clientId,
+            preset: state.preset,
+            auto_refresh: state.autoRefresh ? '1' : '0',
+            refresh_interval: clampInterval(state.refreshInterval)
+        };
+        const anomaliesParams = { client_id: state.clientId };
+        if (range.from) {
+            summaryParams.from = range.from;
+            anomaliesParams.from = range.from;
+        }
+        if (range.to) {
+            summaryParams.to = range.to;
+            anomaliesParams.to = range.to;
+        }
+        const tasks = [
+            request(config.endpoints?.summary, summaryParams)
+                .then((data) => {
+                    updateSummary(data);
+                    return data;
+                })
+                .catch((error) => {
+                    console.error('FPDMS overview summary error', error);
+                    showError(error.message);
+                }),
+            request(config.endpoints?.status, { client_id: state.clientId })
+                .then(updateStatus)
+                .catch((error) => {
+                    console.error('FPDMS overview status error', error);
+                    showError(error.message);
+                }),
+            request(config.endpoints?.anomalies, anomaliesParams)
+                .then(updateAnomalies)
+                .catch((error) => {
+                    console.warn('FPDMS overview anomalies unavailable', error);
+                })
+        ];
+        Promise.allSettled(tasks).then(() => {
+            if (!isAuto) {
+                root.classList.remove('is-loading');
+            }
+            resetLastRefreshLabel();
+            scheduleAutoRefresh();
+        });
+    }
+
+    const prefs = (config.preferences && typeof config.preferences === 'object') ? config.preferences : {};
+
+    if (clientSelect) {
+        const preferredClient = prefs.client_id ? String(prefs.client_id) : '';
+        if (preferredClient) {
+            const match = Array.from(clientSelect.options || []).find((option) => option.value === preferredClient);
+            if (match) {
+                clientSelect.value = preferredClient;
+            }
+        }
+        state.clientId = clientSelect.value;
+    }
+
+    state.preset = normalizePreset(typeof prefs.preset === 'string' ? prefs.preset : state.preset);
+    state.customFrom = typeof prefs.from === 'string' ? prefs.from : '';
+    state.customTo = typeof prefs.to === 'string' ? prefs.to : '';
+    state.autoRefresh = !!prefs.auto_refresh;
+    const storedInterval = typeof prefs.refresh_interval === 'number'
+        ? prefs.refresh_interval
+        : parseInt(prefs.refresh_interval || state.refreshInterval, 10);
+    state.refreshInterval = clampInterval(storedInterval);
+
+    if (refreshToggle) {
+        refreshToggle.checked = state.autoRefresh;
+        refreshToggle.setAttribute('aria-label', config.i18n?.autoRefresh || 'Auto-refresh');
+    }
+    if (refreshSelect) {
+        refreshSelect.value = String(clampInterval(state.refreshInterval));
+        refreshSelect.disabled = !state.autoRefresh;
+        refreshSelect.setAttribute('aria-label', config.i18n?.autoRefreshInterval || 'Auto-refresh interval');
+    }
+
+    resetLastRefreshLabel();
+    setPreset(state.preset, { load: false, preserveCustom: true });
+
+    if (clientSelect) {
+        clientSelect.addEventListener('change', () => {
+            state.clientId = clientSelect.value;
+            loadAll();
+        });
+    }
+
+    presetButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const preset = button.getAttribute('data-fpdms-preset') || 'last7';
+            setPreset(preset);
+        });
+    });
+
+    if (dateFrom) {
+        dateFrom.addEventListener('change', () => {
+            state.customFrom = dateFrom.value;
+            if (state.preset === 'custom' && state.customTo) {
+                loadAll();
+            }
+        });
+    }
+
+    if (dateTo) {
+        dateTo.addEventListener('change', () => {
+            state.customTo = dateTo.value;
+            if (state.preset === 'custom' && state.customFrom) {
+                loadAll();
+            }
+        });
+    }
+
+    if (refreshToggle) {
+        refreshToggle.addEventListener('change', () => {
+            state.autoRefresh = refreshToggle.checked;
+            if (refreshSelect) {
+                refreshSelect.disabled = !state.autoRefresh;
+            }
+            if (!state.autoRefresh) {
+                clearAutoRefreshTimer();
+            }
+            loadAll();
+        });
+    }
+
+    if (refreshSelect) {
+        refreshSelect.addEventListener('change', () => {
+            const interval = clampInterval(parseInt(refreshSelect.value, 10));
+            state.refreshInterval = interval;
+            refreshSelect.value = String(interval);
+            if (state.autoRefresh) {
+                loadAll(true);
+            } else {
+                loadAll();
+            }
+        });
+    }
+
+    if (runButton) {
+        runButton.addEventListener('click', () => {
+            if (!state.clientId) {
+                return;
+            }
+
+            setActionBusy(runButton, true);
+            showActionStatus('info', config.i18n?.runPending || 'Queuing report…');
+
+            const range = computeRange();
+            const payload = { client_id: state.clientId, process: 'now' };
+            if (range.from) {
+                payload.from = range.from;
+            }
+            if (range.to) {
+                payload.to = range.to;
+            }
+
+            postRequest((config.actions && config.actions.run) || (config.endpoints && config.endpoints.run), payload)
+                .then(() => {
+                    showActionStatus('success', config.i18n?.runQueued || 'Report run queued.');
+                    loadAll();
+                })
+                .catch((error) => {
+                    console.error('FPDMS overview run error', error);
+                    showActionStatus('error', error.message || config.i18n?.actionError || 'Action failed. Try again.');
+                })
+                .finally(() => {
+                    setActionBusy(runButton, false);
+                });
+        });
+    }
+
+    if (anomaliesButton) {
+        anomaliesButton.addEventListener('click', () => {
+            if (!state.clientId) {
+                return;
+            }
+
+            setActionBusy(anomaliesButton, true);
+            showActionStatus('info', config.i18n?.anomalyRunning || 'Evaluating anomalies…');
+
+            const range = computePresetRange('last30');
+            const payload = { client_id: state.clientId };
+            if (range.from) {
+                payload.from = range.from;
+            }
+            if (range.to) {
+                payload.to = range.to;
+            }
+
+            postRequest((config.actions && config.actions.anomalies) || (config.endpoints && config.endpoints.anomalies), payload)
+                .then((data) => {
+                    const count = data && typeof data.count === 'number' ? data.count : 0;
+                    if (data && Array.isArray(data.anomalies)) {
+                        updateAnomalies(data);
+                    }
+                    if (count > 0) {
+                        const message = formatCountMessage(config.i18n?.anomalyComplete || 'Anomaly evaluation found %d signals.', count);
+                        showActionStatus('success', message);
+                    } else {
+                        showActionStatus('success', config.i18n?.anomalyNone || 'No anomalies detected in the last 30 days.');
+                    }
+                })
+                .catch((error) => {
+                    console.error('FPDMS overview anomaly evaluation error', error);
+                    showActionStatus('error', error.message || config.i18n?.actionError || 'Action failed. Try again.');
+                })
+                .finally(() => {
+                    setActionBusy(anomaliesButton, false);
+                });
+        });
+    }
+
+    // Initial load
+    if (state.clientId) {
+        loadAll();
+    }
+})();
+<?php
+        echo '</script>';
+    }
+}

--- a/src/Http/OverviewRoutes.php
+++ b/src/Http/OverviewRoutes.php
@@ -1,0 +1,647 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Http;
+
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
+use Exception;
+use FP\DMS\Domain\Repos\AnomaliesRepo;
+use FP\DMS\Domain\Repos\ClientsRepo;
+use FP\DMS\Domain\Repos\ReportsRepo;
+use FP\DMS\Infra\Queue;
+use FP\DMS\Services\Anomalies\Detector;
+use FP\DMS\Services\Overview\Assembler;
+use FP\DMS\Services\Overview\Cache;
+use FP\DMS\Services\Overview\Presenter;
+use FP\DMS\Support\Period;
+use FP\DMS\Support\UserPrefs;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use function absint;
+use function array_map;
+use function get_current_user_id;
+use function get_transient;
+use function sanitize_text_field;
+use function microtime;
+use function is_array;
+use function is_numeric;
+use function sanitize_key;
+use function number_format_i18n;
+use function set_transient;
+use function str_replace;
+use function ucwords;
+use function wp_timezone_string;
+use function wp_date;
+use function rest_sanitize_boolean;
+use function wp_verify_nonce;
+use function wp_unslash;
+use Throwable;
+
+class OverviewRoutes
+{
+    public static function register(): void
+    {
+        register_rest_route('fpdms/v1', '/overview/summary', [
+            'methods' => 'GET',
+            'callback' => [self::class, 'handleSummary'],
+            'permission_callback' => [self::class, 'checkPermissions'],
+            'args' => [
+                'client_id' => [
+                    'required' => true,
+                    'validate_callback' => static fn($value): bool => is_numeric($value) && (int) $value > 0,
+                ],
+                'from' => [
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ],
+                'to' => [
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ],
+                'preset' => [
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_key',
+                ],
+                'auto_refresh' => [
+                    'required' => false,
+                    'sanitize_callback' => 'rest_sanitize_boolean',
+                ],
+                'refresh_interval' => [
+                    'required' => false,
+                    'sanitize_callback' => 'absint',
+                ],
+            ],
+        ]);
+
+        register_rest_route('fpdms/v1', '/overview/trend', [
+            'methods' => 'GET',
+            'callback' => [self::class, 'handleTrend'],
+            'permission_callback' => [self::class, 'checkPermissions'],
+            'args' => [
+                'client_id' => [
+                    'required' => true,
+                    'validate_callback' => static fn($value): bool => is_numeric($value) && (int) $value > 0,
+                ],
+                'metric' => [
+                    'required' => true,
+                    'sanitize_callback' => 'sanitize_key',
+                ],
+                'from' => [
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ],
+                'to' => [
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ],
+            ],
+        ]);
+
+        register_rest_route('fpdms/v1', '/overview/status', [
+            'methods' => 'GET',
+            'callback' => [self::class, 'handleStatus'],
+            'permission_callback' => [self::class, 'checkPermissions'],
+            'args' => [
+                'client_id' => [
+                    'required' => true,
+                    'validate_callback' => static fn($value): bool => is_numeric($value) && (int) $value > 0,
+                ],
+            ],
+        ]);
+
+        register_rest_route('fpdms/v1', '/overview/run', [
+            'methods' => 'POST',
+            'callback' => [self::class, 'handleRun'],
+            'permission_callback' => [self::class, 'checkPermissions'],
+            'args' => [
+                'client_id' => [
+                    'required' => true,
+                    'validate_callback' => static fn($value): bool => is_numeric($value) && (int) $value > 0,
+                ],
+            ],
+        ]);
+
+        register_rest_route('fpdms/v1', '/overview/anomalies', [
+            'methods' => 'POST',
+            'callback' => [self::class, 'handleAnomalies'],
+            'permission_callback' => [self::class, 'checkPermissions'],
+            'args' => [
+                'client_id' => [
+                    'required' => true,
+                    'validate_callback' => static fn($value): bool => is_numeric($value) && (int) $value > 0,
+                ],
+                'from' => [
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ],
+                'to' => [
+                    'required' => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ],
+            ],
+        ]);
+    }
+
+    public static function handleSummary(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        if (! self::verifyNonce($request)) {
+            return new WP_Error('rest_forbidden', __('Invalid or missing nonce.', 'fp-dms'), ['status' => 403]);
+        }
+
+        $rateLimit = self::enforceRateLimit('summary');
+        if ($rateLimit instanceof WP_Error) {
+            return $rateLimit;
+        }
+
+        $clientId = (int) $request->get_param('client_id');
+        $clients = new ClientsRepo();
+        $client = $clients->find($clientId);
+        if (! $client) {
+            return new WP_Error('rest_not_found', __('Client not found.', 'fp-dms'), ['status' => 404]);
+        }
+
+        $presetParam = $request->get_param('preset');
+        $preset = $presetParam ? sanitize_key((string) $presetParam) : 'last7';
+        $range = self::resolveRange($request, $client->timezone ?: wp_timezone_string(), $preset);
+        if ($range instanceof WP_Error) {
+            return $range;
+        }
+
+        $autoRefresh = rest_sanitize_boolean($request->get_param('auto_refresh'));
+        $intervalParam = $request->get_param('refresh_interval');
+        $refreshInterval = $intervalParam !== null ? absint($intervalParam) : 60;
+
+        UserPrefs::rememberOverviewPreferences($clientId, $range['preset'], $range['range']['from'], $range['range']['to'], (bool) $autoRefresh, $refreshInterval);
+
+        $cache = new Cache();
+        $context = [
+            'from' => $range['range']['from'],
+            'to' => $range['range']['to'],
+            'preset' => $range['preset'],
+        ];
+        $cached = $cache->get($clientId, 'summary', $context);
+        if (is_array($cached)) {
+            return new WP_REST_Response($cached);
+        }
+
+        $assembler = new Assembler();
+
+        try {
+            $summary = $assembler->summary($clientId, $range['range']);
+        } catch (Throwable $exception) {
+            return new WP_Error('rest_server_error', __('Unable to compile overview metrics.', 'fp-dms'), ['status' => 500]);
+        }
+
+        $payload = [
+            'client_id' => $clientId,
+            'range' => $range['range'],
+            'summary' => $summary,
+            'refreshed_at' => wp_date('c'),
+        ];
+
+        $cache->set($clientId, 'summary', $payload, 120, $context);
+
+        return new WP_REST_Response($payload);
+    }
+
+    public static function handleTrend(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        if (! self::verifyNonce($request)) {
+            return new WP_Error('rest_forbidden', __('Invalid or missing nonce.', 'fp-dms'), ['status' => 403]);
+        }
+
+        $rateLimit = self::enforceRateLimit('trend');
+        if ($rateLimit instanceof WP_Error) {
+            return $rateLimit;
+        }
+
+        $clientId = (int) $request->get_param('client_id');
+        $metric = sanitize_key((string) $request->get_param('metric'));
+        if ($metric === '') {
+            return new WP_Error('rest_invalid_param', __('Missing metric parameter.', 'fp-dms'), ['status' => 400]);
+        }
+
+        $clients = new ClientsRepo();
+        $client = $clients->find($clientId);
+        if (! $client) {
+            return new WP_Error('rest_not_found', __('Client not found.', 'fp-dms'), ['status' => 404]);
+        }
+
+        $presetParam = $request->get_param('preset');
+        $preset = $presetParam ? sanitize_key((string) $presetParam) : 'last7';
+        $range = self::resolveRange($request, $client->timezone ?: wp_timezone_string(), $preset);
+        if ($range instanceof WP_Error) {
+            return $range;
+        }
+
+        $cache = new Cache();
+        $context = [
+            'from' => $range['range']['from'],
+            'to' => $range['range']['to'],
+            'metric' => $metric,
+            'preset' => $range['preset'],
+        ];
+
+        $cached = $cache->get($clientId, 'trend', $context);
+        if (is_array($cached)) {
+            return new WP_REST_Response($cached);
+        }
+
+        $assembler = new Assembler();
+        try {
+            $trend = $assembler->trend($clientId, $range['range'], $metric);
+        } catch (Throwable $exception) {
+            return new WP_Error('rest_server_error', __('Unable to compile trend data.', 'fp-dms'), ['status' => 500]);
+        }
+
+        $payload = array_merge($trend, [
+            'client_id' => $clientId,
+            'range' => $range['range'],
+        ]);
+
+        $cache->set($clientId, 'trend', $payload, 120, $context);
+
+        return new WP_REST_Response($payload);
+    }
+
+    public static function handleStatus(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        if (! self::verifyNonce($request)) {
+            return new WP_Error('rest_forbidden', __('Invalid or missing nonce.', 'fp-dms'), ['status' => 403]);
+        }
+
+        $rateLimit = self::enforceRateLimit('status');
+        if ($rateLimit instanceof WP_Error) {
+            return $rateLimit;
+        }
+
+        $clientId = (int) $request->get_param('client_id');
+        $clients = new ClientsRepo();
+        $client = $clients->find($clientId);
+        if (! $client) {
+            return new WP_Error('rest_not_found', __('Client not found.', 'fp-dms'), ['status' => 404]);
+        }
+
+        $cache = new Cache();
+        $cached = $cache->get($clientId, 'status');
+        if (is_array($cached)) {
+            return new WP_REST_Response($cached);
+        }
+
+        $assembler = new Assembler();
+        try {
+            $status = $assembler->status($clientId);
+        } catch (Throwable $exception) {
+            return new WP_Error('rest_server_error', __('Unable to load connector status.', 'fp-dms'), ['status' => 500]);
+        }
+
+        $payload = [
+            'client_id' => $clientId,
+            'sources' => self::decorateStatus($status),
+            'checked_at' => wp_date('c'),
+        ];
+
+        $cache->set($clientId, 'status', $payload, 180);
+
+        return new WP_REST_Response($payload);
+    }
+
+    public static function handleRun(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        if (! self::verifyNonce($request)) {
+            return new WP_Error('rest_forbidden', __('Invalid or missing nonce.', 'fp-dms'), ['status' => 403]);
+        }
+
+        $clientId = (int) $request->get_param('client_id');
+        if ($clientId <= 0) {
+            return new WP_Error('rest_invalid_param', __('Missing client_id parameter.', 'fp-dms'), ['status' => 400]);
+        }
+
+        $clients = new ClientsRepo();
+        $client = $clients->find($clientId);
+        if (! $client) {
+            return new WP_Error('rest_not_found', __('Client not found.', 'fp-dms'), ['status' => 404]);
+        }
+
+        $timezoneName = $client->timezone ?: wp_timezone_string();
+        try {
+            $tz = new DateTimeZone($timezoneName ?: 'UTC');
+        } catch (Exception $exception) {
+            return new WP_Error('rest_invalid_param', __('Invalid timezone configured for client.', 'fp-dms'), ['status' => 400]);
+        }
+
+        $fromParam = $request->get_param('from');
+        $toParam = $request->get_param('to');
+        $from = $fromParam ? sanitize_text_field((string) $fromParam) : '';
+        $to = $toParam ? sanitize_text_field((string) $toParam) : '';
+
+        if ($from === '' || $to === '') {
+            $end = new DateTimeImmutable('now', $tz);
+            $start = $end->modify('-6 days');
+            $from = $start->format('Y-m-d');
+            $to = $end->format('Y-m-d');
+        }
+
+        try {
+            $period = Period::fromStrings($from, $to, $timezoneName ?: null);
+        } catch (Exception $exception) {
+            return new WP_Error('rest_invalid_param', __('Invalid date range provided.', 'fp-dms'), ['status' => 400]);
+        }
+
+        if ($period->end < $period->start) {
+            return new WP_Error('rest_invalid_param', __('The end date must be after the start date.', 'fp-dms'), ['status' => 400]);
+        }
+
+        $job = Queue::enqueue($clientId, $period->start->format('Y-m-d'), $period->end->format('Y-m-d'), null, null, ['origin' => 'overview']);
+        if (! $job) {
+            return new WP_Error('rest_cannot_create', __('Unable to queue report.', 'fp-dms'), ['status' => 500]);
+        }
+
+        if ((string) $request->get_param('process') === 'now') {
+            Queue::tick();
+        }
+
+        return new WP_REST_Response([
+            'ok' => true,
+            'report_id' => $job->id,
+            'client_id' => $clientId,
+            'period' => [
+                'from' => $period->start->format('Y-m-d'),
+                'to' => $period->end->format('Y-m-d'),
+            ],
+        ]);
+    }
+
+    public static function handleAnomalies(WP_REST_Request $request): WP_REST_Response|WP_Error
+    {
+        if (! self::verifyNonce($request)) {
+            return new WP_Error('rest_forbidden', __('Invalid or missing nonce.', 'fp-dms'), ['status' => 403]);
+        }
+
+        $clientId = (int) $request->get_param('client_id');
+        if ($clientId <= 0) {
+            return new WP_Error('rest_invalid_param', __('Missing client_id parameter.', 'fp-dms'), ['status' => 400]);
+        }
+
+        $clients = new ClientsRepo();
+        $client = $clients->find($clientId);
+        if (! $client) {
+            return new WP_Error('rest_not_found', __('Client not found.', 'fp-dms'), ['status' => 404]);
+        }
+
+        $timezoneName = $client->timezone ?: wp_timezone_string();
+        try {
+            $tz = new DateTimeZone($timezoneName ?: 'UTC');
+        } catch (Exception $exception) {
+            return new WP_Error('rest_invalid_param', __('Invalid timezone configured for client.', 'fp-dms'), ['status' => 400]);
+        }
+
+        $fromParam = $request->get_param('from');
+        $toParam = $request->get_param('to');
+        $from = $fromParam ? sanitize_text_field((string) $fromParam) : '';
+        $to = $toParam ? sanitize_text_field((string) $toParam) : '';
+
+        if ($from === '' || $to === '') {
+            $end = new DateTimeImmutable('now', $tz);
+            $start = $end->modify('-29 days');
+            $from = $start->format('Y-m-d');
+            $to = $end->format('Y-m-d');
+        }
+
+        try {
+            $period = Period::fromStrings($from, $to, $timezoneName ?: null);
+        } catch (Exception $exception) {
+            return new WP_Error('rest_invalid_param', __('Invalid date range provided.', 'fp-dms'), ['status' => 400]);
+        }
+
+        if ($period->end < $period->start) {
+            return new WP_Error('rest_invalid_param', __('The end date must be after the start date.', 'fp-dms'), ['status' => 400]);
+        }
+
+        $reports = new ReportsRepo();
+        $report = $reports->findByClientAndPeriod($clientId, $period->start->format('Y-m-d'), $period->end->format('Y-m-d'), ['success']);
+        if (! $report) {
+            return new WP_Error('rest_not_found', __('No report data available for evaluation.', 'fp-dms'), ['status' => 404]);
+        }
+
+        $evaluationPeriod = Period::fromStrings($report->periodStart, $report->periodEnd, $timezoneName ?: null);
+        $detector = new Detector(new AnomaliesRepo());
+        $anomalies = $detector->evaluatePeriod($clientId, $evaluationPeriod, $report->meta, [], false);
+        $formattedAnomalies = self::decorateAnomalies($anomalies);
+
+        return new WP_REST_Response([
+            'ok' => true,
+            'client_id' => $clientId,
+            'count' => count($formattedAnomalies),
+            'anomalies' => $formattedAnomalies,
+            'period' => [
+                'from' => $evaluationPeriod->start->format('Y-m-d'),
+                'to' => $evaluationPeriod->end->format('Y-m-d'),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array{period: Period, range: array{from: string, to: string}, preset: string}|WP_Error
+     */
+    private static function resolveRange(WP_REST_Request $request, string $timezone, string $preset): array|WP_Error
+    {
+        $normalizedPreset = $preset !== '' ? $preset : 'last7';
+        $from = trim((string) $request->get_param('from'));
+        $to = trim((string) $request->get_param('to'));
+
+        if ($from === '' || $to === '') {
+            $defaults = self::defaultRangeForPreset($normalizedPreset, $timezone);
+            $from = $defaults['from'];
+            $to = $defaults['to'];
+        }
+
+        try {
+            $period = Period::fromStrings($from, $to, $timezone ?: null);
+        } catch (Exception $exception) {
+            return new WP_Error('rest_invalid_param', __('Invalid date range provided.', 'fp-dms'), ['status' => 400]);
+        }
+
+        if ($period->end < $period->start) {
+            return new WP_Error('rest_invalid_param', __('The end date must be after the start date.', 'fp-dms'), ['status' => 400]);
+        }
+
+        return [
+            'period' => $period,
+            'range' => [
+                'from' => $period->start->format('Y-m-d'),
+                'to' => $period->end->format('Y-m-d'),
+            ],
+            'preset' => $normalizedPreset,
+        ];
+    }
+
+    /**
+     * @return array{from: string, to: string}
+     */
+    private static function defaultRangeForPreset(string $preset, string $timezone): array
+    {
+        try {
+            $tz = new DateTimeZone($timezone ?: 'UTC');
+        } catch (Exception $exception) {
+            $tz = new DateTimeZone('UTC');
+        }
+
+        $today = new DateTimeImmutable('today', $tz);
+
+        switch ($preset) {
+            case 'last14':
+                $start = $today->sub(new DateInterval('P13D'));
+                $end = $today;
+                break;
+            case 'last28':
+                $start = $today->sub(new DateInterval('P27D'));
+                $end = $today;
+                break;
+            case 'this_month':
+                $start = $today->modify('first day of this month');
+                $end = $today;
+                break;
+            case 'last_month':
+                $firstOfThisMonth = $today->modify('first day of this month');
+                $start = $firstOfThisMonth->modify('-1 month');
+                $end = $firstOfThisMonth->modify('-1 day');
+                break;
+            default:
+                $start = $today->sub(new DateInterval('P6D'));
+                $end = $today;
+                break;
+        }
+
+        return [
+            'from' => $start->format('Y-m-d'),
+            'to' => $end->format('Y-m-d'),
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $status
+     * @return array<int, array<string, mixed>>
+     */
+    private static function decorateStatus(array $status): array
+    {
+        return array_map(
+            static function (array $entry): array {
+                $state = isset($entry['state']) ? (string) $entry['state'] : '';
+                $entry['state_label'] = self::statusLabel($state);
+
+                return $entry;
+            },
+            $status
+        );
+    }
+
+    private static function statusLabel(string $state): string
+    {
+        return match ($state) {
+            'ok' => __('OK', 'fp-dms'),
+            'missing' => __('Missing', 'fp-dms'),
+            'inactive' => __('Inactive', 'fp-dms'),
+            'misconfigured' => __('Misconfigured', 'fp-dms'),
+            'no_data' => __('No data', 'fp-dms'),
+            default => __('Unknown', 'fp-dms'),
+        };
+    }
+
+    /**
+     * @param array<int, mixed> $anomalies
+     * @return array<int, array<string, mixed>>
+     */
+    private static function decorateAnomalies(array $anomalies): array
+    {
+        $decorated = [];
+
+        foreach ($anomalies as $anomaly) {
+            if (! is_array($anomaly)) {
+                continue;
+            }
+
+            $score = 0.0;
+            if (isset($anomaly['score']) && is_numeric($anomaly['score'])) {
+                $score = (float) $anomaly['score'];
+            } elseif (isset($anomaly['severity']) && is_numeric($anomaly['severity'])) {
+                $score = (float) $anomaly['severity'];
+            }
+
+            $badge = Presenter::severityBadge($score);
+            $anomaly['severity_variant'] = $badge['variant'];
+            $anomaly['severity_label'] = $badge['label'];
+
+            if (! isset($anomaly['metric_label']) && isset($anomaly['metric'])) {
+                $anomaly['metric_label'] = self::humanizeMetric((string) $anomaly['metric']);
+            }
+
+            if (! isset($anomaly['delta_formatted']) && isset($anomaly['delta'])) {
+                if (is_array($anomaly['delta']) && isset($anomaly['delta']['formatted'])) {
+                    $anomaly['delta_formatted'] = (string) $anomaly['delta']['formatted'];
+                } elseif (is_numeric($anomaly['delta'])) {
+                    $value = (float) $anomaly['delta'];
+                    $anomaly['delta_formatted'] = sprintf('%s%s%%', $value > 0 ? '+' : '', number_format_i18n($value, 1));
+                }
+            }
+
+            $decorated[] = $anomaly;
+        }
+
+        return $decorated;
+    }
+
+    private static function humanizeMetric(string $metric): string
+    {
+        $normalized = str_replace('_', ' ', $metric);
+
+        return ucwords($normalized);
+    }
+
+    private static function enforceRateLimit(string $bucket): WP_Error|bool
+    {
+        $userId = get_current_user_id();
+        if ($userId <= 0) {
+            return true;
+        }
+
+        $key = 'fpdms_overview_rate_' . $bucket . '_' . $userId;
+        $last = get_transient($key);
+        $now = microtime(true);
+
+        if (is_numeric($last) && ($now - (float) $last) < 1) {
+            return new WP_Error('rest_too_many_requests', __('Please wait a moment before refreshing again.', 'fp-dms'), ['status' => 429]);
+        }
+
+        set_transient($key, (string) $now, 2);
+
+        return true;
+    }
+
+    public static function checkPermissions(): bool
+    {
+        return current_user_can('manage_options');
+    }
+
+    private static function verifyNonce(WP_REST_Request $request): bool
+    {
+        $nonce = $request->get_header('X-WP-Nonce');
+        if (! $nonce) {
+            $nonce = $request->get_param('_wpnonce');
+        }
+
+        if (is_array($nonce)) {
+            $nonce = reset($nonce);
+        }
+
+        if (! is_string($nonce)) {
+            return false;
+        }
+
+        return wp_verify_nonce(wp_unslash($nonce), 'wp_rest') !== false;
+    }
+}

--- a/src/Http/Routes.php
+++ b/src/Http/Routes.php
@@ -29,6 +29,8 @@ class Routes
 
     public static function onRestInit(): void
     {
+        OverviewRoutes::register();
+
         register_rest_route('fpdms/v1', '/tick', [
             'methods' => 'POST',
             'callback' => [self::class, 'handleTick'],

--- a/src/Services/Overview/Assembler.php
+++ b/src/Services/Overview/Assembler.php
@@ -1,0 +1,457 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Services\Overview;
+
+use DateInterval;
+use DateTimeImmutable;
+use Exception;
+use FP\DMS\Domain\Entities\DataSource;
+use FP\DMS\Domain\Repos\DataSourcesRepo;
+use FP\DMS\Services\Connectors\ProviderFactory;
+use FP\DMS\Support\Dates;
+use FP\DMS\Support\Period;
+use Throwable;
+use function __;
+use function array_fill_keys;
+use function array_map;
+use function count;
+use function is_array;
+use function is_numeric;
+use function sanitize_key;
+
+class Assembler
+{
+    /** @var array<string, array{label: string, precision: int}> */
+    private const KPI_MAP = [
+        'users' => ['label' => 'Users', 'precision' => 0],
+        'sessions' => ['label' => 'Sessions', 'precision' => 0],
+        'clicks' => ['label' => 'Clicks', 'precision' => 0],
+        'impressions' => ['label' => 'Impressions', 'precision' => 0],
+        'cost' => ['label' => 'Cost', 'precision' => 2],
+        'conversions' => ['label' => 'Conversions', 'precision' => 2],
+        'revenue' => ['label' => 'Revenue', 'precision' => 2],
+        'gsc_clicks' => ['label' => 'GSC Clicks', 'precision' => 0],
+        'gsc_impressions' => ['label' => 'GSC Impressions', 'precision' => 0],
+    ];
+
+    /** @var array<string, array<string, string>> */
+    private const SOURCE_METRICS = [
+        'ga4' => [
+            'users' => 'users',
+            'sessions' => 'sessions',
+            'revenue' => 'revenue',
+        ],
+        'google_ads' => [
+            'clicks' => 'clicks',
+            'impressions' => 'impressions',
+            'cost' => 'cost',
+            'conversions' => 'conversions',
+        ],
+        'meta_ads' => [
+            'clicks' => 'clicks',
+            'impressions' => 'impressions',
+            'cost' => 'cost',
+            'conversions' => 'conversions',
+        ],
+        'gsc' => [
+            'clicks' => 'gsc_clicks',
+            'impressions' => 'gsc_impressions',
+        ],
+    ];
+
+    /** @var array<string, array{label: string}> */
+    private const STATUS_TYPES = [
+        'ga4' => ['label' => 'GA4'],
+        'gsc' => ['label' => 'GSC'],
+        'google_ads' => ['label' => 'Google Ads'],
+        'meta_ads' => ['label' => 'Meta Ads'],
+        'clarity' => ['label' => 'Clarity'],
+        'csv_generic' => ['label' => 'Generic'],
+    ];
+
+    /** @var array<string, array{auth?: string[], config?: string[]}> */
+    private const SOURCE_REQUIREMENTS = [
+        'ga4' => ['auth' => ['service_account'], 'config' => ['property_id']],
+        'gsc' => ['auth' => ['service_account'], 'config' => ['site_url']],
+    ];
+
+    public function __construct(private ?DataSourcesRepo $dataSourcesRepo = null)
+    {
+        $this->dataSourcesRepo = $dataSourcesRepo ?: new DataSourcesRepo();
+    }
+
+    /**
+     * @param array<string, string> $period
+     * @return array<string, mixed>
+     */
+    public function summary(int $clientId, array $period): array
+    {
+        $range = $this->resolvePeriod($period);
+        $previous = Dates::prevComparable($range);
+
+        $currentSeries = $this->collectSeries($clientId, $range);
+        $previousSeries = $this->collectSeries($clientId, $previous);
+
+        $kpis = [];
+        foreach (self::KPI_MAP as $metric => $config) {
+            $currentValue = $currentSeries['totals'][$metric] ?? 0.0;
+            $previousValue = $previousSeries['totals'][$metric] ?? 0.0;
+            $delta = Presenter::formatDelta($currentValue, $previousValue);
+            $sparklineValues = array_map(
+                static fn(array $metrics): float => (float) ($metrics[$metric] ?? 0.0),
+                $currentSeries['daily']
+            );
+
+            $kpis[] = [
+                'metric' => $metric,
+                'label' => __($config['label'], 'fp-dms'),
+                'value' => $currentValue,
+                'formatted_value' => Presenter::formatNumber($currentValue, $config['precision']),
+                'previous_value' => $previousValue,
+                'formatted_previous' => Presenter::formatNumber($previousValue, $config['precision']),
+                'delta' => $delta,
+                'sparkline' => Sparkline::normalize($sparklineValues),
+            ];
+        }
+
+        return [
+            'period' => [
+                'from' => $range->start->format('Y-m-d'),
+                'to' => $range->end->format('Y-m-d'),
+                'days' => count($currentSeries['daily']),
+            ],
+            'comparison' => [
+                'from' => $previous->start->format('Y-m-d'),
+                'to' => $previous->end->format('Y-m-d'),
+            ],
+            'kpis' => $kpis,
+            'series' => $currentSeries['daily'],
+        ];
+    }
+
+    /**
+     * @param array<string, string> $period
+     * @return array<string, mixed>
+     */
+    public function trend(int $clientId, array $period, string $metric): array
+    {
+        $range = $this->resolvePeriod($period);
+        $series = $this->collectSeries($clientId, $range);
+
+        $points = [];
+        foreach ($series['daily'] as $date => $metrics) {
+            $points[] = [
+                'date' => $date,
+                'value' => (float) ($metrics[$metric] ?? 0.0),
+            ];
+        }
+
+        return [
+            'metric' => $metric,
+            'period' => [
+                'from' => $range->start->format('Y-m-d'),
+                'to' => $range->end->format('Y-m-d'),
+            ],
+            'series' => $points,
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function status(int $clientId): array
+    {
+        $sources = $this->dataSourcesRepo->forClient($clientId);
+        $status = [];
+
+        foreach (self::STATUS_TYPES as $type => $meta) {
+            $entry = [
+                'type' => $type,
+                'label' => __($meta['label'], 'fp-dms'),
+            ];
+
+            $dataSource = $this->findSourceByType($sources, $type);
+            if (! $dataSource) {
+                $status[] = $entry + [
+                    'state' => 'missing',
+                    'message' => __('Connector not configured.', 'fp-dms'),
+                    'last_updated' => null,
+                ];
+                continue;
+            }
+
+            $status[] = $entry + $this->buildStatusPayload($dataSource);
+        }
+
+        return $status;
+    }
+
+    /**
+     * @param array<int, DataSource> $sources
+     */
+    private function findSourceByType(array $sources, string $type): ?DataSource
+    {
+        foreach ($sources as $source) {
+            if ($source->type === $type) {
+                return $source;
+            }
+        }
+
+        return null;
+    }
+
+    private function buildStatusPayload(DataSource $source): array
+    {
+        if (! $source->active) {
+            return [
+                'state' => 'inactive',
+                'message' => __('Connector is disabled.', 'fp-dms'),
+                'last_updated' => null,
+            ];
+        }
+
+        if (! $this->meetsRequirements($source)) {
+            return [
+                'state' => 'misconfigured',
+                'message' => __('Connector misconfigured. Review credentials and settings.', 'fp-dms'),
+                'last_updated' => null,
+            ];
+        }
+
+        $summary = $this->extractSummary($source);
+        $lastUpdated = $this->extractLastUpdated($summary);
+        $hasMetrics = $this->summaryHasMetrics($summary);
+
+        if (! $hasMetrics) {
+            return [
+                'state' => 'no_data',
+                'message' => __('No recent data ingested.', 'fp-dms'),
+                'last_updated' => $lastUpdated,
+            ];
+        }
+
+        return [
+            'state' => 'ok',
+            'message' => __('Data available.', 'fp-dms'),
+            'last_updated' => $lastUpdated,
+        ];
+    }
+
+    private function meetsRequirements(DataSource $source): bool
+    {
+        $requirements = self::SOURCE_REQUIREMENTS[$source->type] ?? null;
+        if ($requirements === null) {
+            return true;
+        }
+
+        if (isset($requirements['auth'])) {
+            foreach ($requirements['auth'] as $key) {
+                if (empty($source->auth[$key])) {
+                    return false;
+                }
+            }
+        }
+
+        if (isset($requirements['config'])) {
+            foreach ($requirements['config'] as $key) {
+                if (empty($source->config[$key])) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private function extractSummary(DataSource $source): ?array
+    {
+        $summary = $source->config['summary'] ?? null;
+
+        return is_array($summary) ? $summary : null;
+    }
+
+    private function extractLastUpdated(?array $summary): ?string
+    {
+        if (! $summary) {
+            return null;
+        }
+
+        foreach (['last_ingested_at', 'updated_at', 'generated_at'] as $key) {
+            if (! empty($summary[$key]) && is_string($summary[$key])) {
+                return $summary[$key];
+            }
+        }
+
+        return null;
+    }
+
+    private function summaryHasMetrics(?array $summary): bool
+    {
+        if (! $summary) {
+            return false;
+        }
+
+        if (! empty($summary['metrics']) && is_array($summary['metrics'])) {
+            foreach ($summary['metrics'] as $value) {
+                if (is_numeric($value) && (float) $value !== 0.0) {
+                    return true;
+                }
+            }
+        }
+
+        if (! empty($summary['daily']) && is_array($summary['daily'])) {
+            foreach ($summary['daily'] as $metrics) {
+                if (! is_array($metrics)) {
+                    continue;
+                }
+                foreach ($metrics as $value) {
+                    if (is_numeric($value) && (float) $value !== 0.0) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string, string> $period
+     */
+    private function resolvePeriod(array $period): Period
+    {
+        $now = new DateTimeImmutable('now');
+        $start = $this->parseDate($period['from'] ?? '') ?? $now->sub(new DateInterval('P6D'));
+        $end = $this->parseDate($period['to'] ?? '') ?? $now;
+
+        if ($end < $start) {
+            [$start, $end] = [$end, $start];
+        }
+
+        return new Period($start, $end);
+    }
+
+    private function parseDate(string $value): ?DateTimeImmutable
+    {
+        if ($value === '') {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $exception) {
+            return null;
+        }
+    }
+
+    private function safeDate(string $candidate, DateTimeImmutable $fallback): ?string
+    {
+        if ($candidate === '') {
+            return $fallback->format('Y-m-d');
+        }
+
+        try {
+            $date = new DateTimeImmutable($candidate);
+        } catch (Exception $exception) {
+            return null;
+        }
+
+        return $date->format('Y-m-d');
+    }
+
+    /**
+     * @return array{daily: array<string, array<string, float>>, totals: array<string, float>}
+     */
+    private function collectSeries(int $clientId, Period $period): array
+    {
+        $sources = $this->dataSourcesRepo->forClient($clientId);
+        $daily = [];
+        $totals = array_fill_keys(array_keys(self::KPI_MAP), 0.0);
+
+        foreach ($sources as $dataSource) {
+            if (! $dataSource->active) {
+                continue;
+            }
+
+            $provider = ProviderFactory::create($dataSource->type, $dataSource->auth, $dataSource->config);
+            if (! $provider) {
+                continue;
+            }
+
+            try {
+                $rows = $provider->fetchMetrics($period);
+            } catch (Throwable $throwable) {
+                continue;
+            }
+
+            foreach ($rows as $row) {
+                if (! is_array($row)) {
+                    continue;
+                }
+
+                $sourceKey = isset($row['source']) ? (string) $row['source'] : $dataSource->type;
+                $metrics = $this->mapMetrics($sourceKey, $row);
+                if ($metrics === []) {
+                    continue;
+                }
+
+                $date = isset($row['date']) ? (string) $row['date'] : '';
+                $normalizedDate = $this->safeDate($date, $period->end);
+                if (! $normalizedDate) {
+                    continue;
+                }
+
+                if (! isset($daily[$normalizedDate])) {
+                    $daily[$normalizedDate] = array_fill_keys(array_keys(self::KPI_MAP), 0.0);
+                }
+
+                foreach ($metrics as $metric => $value) {
+                    $daily[$normalizedDate][$metric] = ($daily[$normalizedDate][$metric] ?? 0.0) + (float) $value;
+                    $totals[$metric] = ($totals[$metric] ?? 0.0) + (float) $value;
+                }
+            }
+        }
+
+        $filled = [];
+        foreach (Dates::rangeDays($period->start, $period->end) as $date) {
+            $filled[$date] = array_merge(
+                array_fill_keys(array_keys(self::KPI_MAP), 0.0),
+                $daily[$date] ?? []
+            );
+        }
+
+        return [
+            'daily' => $filled,
+            'totals' => array_map(
+                static fn(float $value): float => round($value, 2),
+                $totals
+            ),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @return array<string, float>
+     */
+    private function mapMetrics(string $source, array $row): array
+    {
+        $source = sanitize_key($source);
+        $map = self::SOURCE_METRICS[$source] ?? null;
+        if ($map === null) {
+            return [];
+        }
+
+        $metrics = [];
+        foreach ($map as $original => $target) {
+            if (! isset($row[$original]) || ! is_numeric($row[$original])) {
+                continue;
+            }
+
+            $metrics[$target] = ($metrics[$target] ?? 0.0) + (float) $row[$original];
+        }
+
+        return $metrics;
+    }
+}

--- a/src/Services/Overview/Cache.php
+++ b/src/Services/Overview/Cache.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Services\Overview;
+
+use function delete_transient;
+use function get_transient;
+use function is_scalar;
+use function ksort;
+use function md5;
+use function sanitize_key;
+use function set_transient;
+use function substr;
+use function wp_json_encode;
+
+class Cache
+{
+    private string $prefix;
+
+    public function __construct(?string $prefix = null)
+    {
+        $this->prefix = $prefix ? sanitize_key($prefix) : 'fpdms_overview';
+    }
+
+    /**
+     * @param array<string, scalar> $context
+     */
+    public function get(int $clientId, string $section, array $context = []): mixed
+    {
+        $key = $this->buildKey($clientId, $section, $context);
+        $cached = get_transient($key);
+
+        return $cached === false ? null : $cached;
+    }
+
+    /**
+     * @param array<string, scalar> $context
+     */
+    public function set(int $clientId, string $section, mixed $value, int $ttl = 90, array $context = []): bool
+    {
+        $key = $this->buildKey($clientId, $section, $context);
+
+        return set_transient($key, $value, $ttl);
+    }
+
+    /**
+     * @param array<string, scalar> $context
+     */
+    public function clear(int $clientId, string $section, array $context = []): void
+    {
+        $key = $this->buildKey($clientId, $section, $context);
+        delete_transient($key);
+    }
+
+    /**
+     * @param array<string, scalar> $context
+     */
+    private function buildKey(int $clientId, string $section, array $context = []): string
+    {
+        $normalized = [];
+        foreach ($context as $key => $value) {
+            if (! is_scalar($value)) {
+                continue;
+            }
+            $normalized[sanitize_key((string) $key)] = (string) $value;
+        }
+
+        $payload = ['client' => $clientId, 'section' => sanitize_key($section)] + $normalized;
+        ksort($payload);
+        $hash = md5((string) wp_json_encode($payload));
+
+        return substr($this->prefix . '_' . $clientId . '_' . $hash, 0, 172);
+    }
+}

--- a/src/Services/Overview/Presenter.php
+++ b/src/Services/Overview/Presenter.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Services\Overview;
+
+use function __;
+use function abs;
+use function number_format_i18n;
+use function sprintf;
+
+class Presenter
+{
+    public static function formatNumber(float $value, int $precision = 0): string
+    {
+        if (abs($value) >= 1000 && $precision === 0) {
+            $precision = 1;
+        }
+
+        return number_format_i18n($value, $precision);
+    }
+
+    /**
+     * @return array{raw: float, formatted: string, direction: 'up'|'down'|'flat'}
+     */
+    public static function formatDelta(float $current, float $previous, int $precision = 1): array
+    {
+        if ($previous === 0.0) {
+            if ($current === 0.0) {
+                $raw = 0.0;
+                $direction = 'flat';
+            } else {
+                $raw = 100.0;
+                $direction = $current > 0 ? 'up' : 'down';
+            }
+        } else {
+            $raw = (($current - $previous) / abs($previous)) * 100;
+            $direction = $raw > 0 ? 'up' : ($raw < 0 ? 'down' : 'flat');
+        }
+
+        $formatted = sprintf('%s%s%%', $raw > 0 ? '+' : '', number_format_i18n($raw, $precision));
+
+        return [
+            'raw' => $raw,
+            'formatted' => $formatted,
+            'direction' => $direction,
+        ];
+    }
+
+    /**
+     * @return array{variant: string, label: string}
+     */
+    public static function severityBadge(float $score): array
+    {
+        $variant = 'neutral';
+        $label = __('Info', 'fp-dms');
+
+        if ($score >= 7.5) {
+            $variant = 'critical';
+            $label = __('Critical', 'fp-dms');
+        } elseif ($score >= 4.0) {
+            $variant = 'warning';
+            $label = __('Warning', 'fp-dms');
+        } elseif ($score >= 1.5) {
+            $variant = 'info';
+            $label = __('Notice', 'fp-dms');
+        }
+
+        return [
+            'variant' => $variant,
+            'label' => $label,
+        ];
+    }
+}

--- a/src/Services/Overview/Sparkline.php
+++ b/src/Services/Overview/Sparkline.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Services\Overview;
+
+class Sparkline
+{
+    /**
+     * @param array<int, float> $values
+     * @return array<int, array{y: float, x: int}>
+     */
+    public static function normalize(array $values, int $maxPoints = 20): array
+    {
+        $values = array_values(array_map('floatval', $values));
+        if ($values === []) {
+            return [];
+        }
+
+        $sampled = self::downSample($values, $maxPoints);
+        $max = max($sampled);
+        $min = min($sampled);
+        $range = $max - $min;
+        if ($range <= 0) {
+            $range = 1;
+        }
+
+        $points = [];
+        foreach ($sampled as $index => $value) {
+            $points[] = [
+                'x' => $index,
+                'y' => ($value - $min) / $range,
+            ];
+        }
+
+        return $points;
+    }
+
+    /**
+     * @param array<int, float> $values
+     * @return array<int, float>
+     */
+    private static function downSample(array $values, int $limit): array
+    {
+        $total = count($values);
+        if ($total <= $limit) {
+            return $values;
+        }
+
+        $ratio = $total / $limit;
+        $sampled = [];
+        for ($i = 0; $i < $total; $i++) {
+            $bucket = (int) floor($i / $ratio);
+            if (! isset($sampled[$bucket])) {
+                $sampled[$bucket] = [];
+            }
+            $sampled[$bucket][] = $values[$i];
+        }
+
+        return array_map(
+            static fn(array $bucket): float => array_sum($bucket) / max(count($bucket), 1),
+            $sampled
+        );
+    }
+}

--- a/src/Support/UserPrefs.php
+++ b/src/Support/UserPrefs.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Support;
+
+use DateTimeImmutable;
+
+use function absint;
+use function get_current_user_id;
+use function get_user_meta;
+use function is_array;
+use function sanitize_key;
+use function trim;
+use function update_user_meta;
+
+final class UserPrefs
+{
+    private const META_KEY = '_fpdms_prefs';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function getOverviewPreferences(): array
+    {
+        $userId = get_current_user_id();
+        if ($userId <= 0) {
+            return [];
+        }
+
+        $stored = get_user_meta($userId, self::META_KEY, true);
+        if (! is_array($stored)) {
+            return [];
+        }
+
+        $prefs = $stored['overview'] ?? [];
+
+        return is_array($prefs) ? self::sanitizeOverviewPreferences($prefs) : [];
+    }
+
+    public static function rememberOverviewPreferences(
+        int $clientId,
+        string $preset,
+        string $from,
+        string $to,
+        bool $autoRefresh,
+        int $refreshInterval
+    ): void {
+        $userId = get_current_user_id();
+        if ($userId <= 0) {
+            return;
+        }
+
+        $meta = get_user_meta($userId, self::META_KEY, true);
+        if (! is_array($meta)) {
+            $meta = [];
+        }
+
+        $meta['overview'] = [
+            'client_id' => absint($clientId),
+            'preset' => sanitize_key($preset),
+            'from' => self::sanitizeDate($from),
+            'to' => self::sanitizeDate($to),
+            'auto_refresh' => $autoRefresh,
+            'refresh_interval' => self::sanitizeInterval($refreshInterval),
+        ];
+
+        update_user_meta($userId, self::META_KEY, $meta);
+    }
+
+    private static function sanitizeDate(string $date): string
+    {
+        $date = trim($date);
+        if ($date === '') {
+            return '';
+        }
+
+        $parsed = DateTimeImmutable::createFromFormat('Y-m-d', $date);
+
+        return $parsed ? $parsed->format('Y-m-d') : '';
+    }
+
+    private static function sanitizeInterval(int $seconds): int
+    {
+        $seconds = absint($seconds);
+        if ($seconds < 30) {
+            $seconds = 30;
+        }
+
+        if ($seconds > 600) {
+            $seconds = 600;
+        }
+
+        return $seconds;
+    }
+
+    /**
+     * @param array<string, mixed> $prefs
+     *
+     * @return array<string, mixed>
+     */
+    private static function sanitizeOverviewPreferences(array $prefs): array
+    {
+        return [
+            'client_id' => isset($prefs['client_id']) ? absint((int) $prefs['client_id']) : 0,
+            'preset' => isset($prefs['preset']) ? sanitize_key((string) $prefs['preset']) : '',
+            'from' => isset($prefs['from']) ? self::sanitizeDate((string) $prefs['from']) : '',
+            'to' => isset($prefs['to']) ? self::sanitizeDate((string) $prefs['to']) : '',
+            'auto_refresh' => ! empty($prefs['auto_refresh']),
+            'refresh_interval' => isset($prefs['refresh_interval'])
+                ? self::sanitizeInterval((int) $prefs['refresh_interval'])
+                : 60,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- wire the overview REST endpoints to the assembler cache so summary, trend, status, and anomaly payloads return formatted data
- polish the admin overview page with translated error messaging, status timestamps, and accessibility tweaks
- document the live dashboard in the README and mark the workflow tracker complete

## Testing
- php -l src/Admin/Pages/OverviewPage.php
- php -l src/Http/OverviewRoutes.php


------
https://chatgpt.com/codex/tasks/task_e_68dbe9d1621c832f902e40b38dcd08f5