### PR TITLE
Add Meta Ads summary ingestion and parsing

### DIFF
--- a/fp-digital-marketing-suite.php
+++ b/fp-digital-marketing-suite.php
@@ -16,6 +16,7 @@
 declare(strict_types=1);
 
 use FP\DMS\Admin\Menu;
+use FP\DMS\Admin\Support\Ajax\TestConnector;
 use FP\DMS\Cli\Commands;
 use FP\DMS\Http\Routes;
 use FP\DMS\Infra\Activator;
@@ -84,6 +85,7 @@ function fp_dms_bootstrap(): void
     }
 
     Security::registerAdminNotice();
+    TestConnector::register();
     Menu::init();
 }
 add_action('init', 'fp_dms_bootstrap');

--- a/src/Admin/Pages/ClientsPage.php
+++ b/src/Admin/Pages/ClientsPage.php
@@ -8,12 +8,21 @@ use DateTimeZone;
 use Exception;
 use FP\DMS\Admin\Support\NoticeStore;
 use FP\DMS\Domain\Repos\ClientsRepo;
+use FP\DMS\Services\Connectors\CentralServiceAccount;
+use FP\DMS\Services\Connectors\ClientConnectorValidator;
 use FP\DMS\Support\Wp;
 use function __;
+use function esc_attr;
+use function esc_html;
 use function esc_html__;
+use function esc_js;
+use function esc_textarea;
 use function esc_url;
 use function get_post;
+use function sprintf;
+use function wp_create_nonce;
 use function wp_enqueue_media;
+use function wp_enqueue_script;
 use function wp_get_attachment_image_url;
 
 class ClientsPage
@@ -56,6 +65,10 @@ class ClientsPage
                 'timezone' => Wp::sanitizeTextField($post['timezone'] ?? 'UTC'),
                 'notes' => Wp::ksesPost((string) ($post['notes'] ?? '')),
                 'logo_id' => self::sanitizeLogoId($post['logo_id'] ?? null),
+                'ga4_property_id' => ClientConnectorValidator::sanitizeGa4PropertyId($post['ga4_property_id'] ?? ''),
+                'ga4_stream_id' => ClientConnectorValidator::sanitizeGa4StreamId($post['ga4_stream_id'] ?? ''),
+                'ga4_measurement_id' => ClientConnectorValidator::sanitizeGa4MeasurementId($post['ga4_measurement_id'] ?? ''),
+                'gsc_site_property' => ClientConnectorValidator::sanitizeGscSiteProperty($post['gsc_site_property'] ?? ''),
             ];
 
             $fallbackTz = $existing?->timezone ?? 'UTC';
@@ -162,9 +175,18 @@ class ClientsPage
         $emailCc = $client ? implode(', ', $client->emailCc) : '';
 
         wp_enqueue_media();
+        wp_enqueue_script('jquery');
         $logoId = $client?->logoId ?? null;
         $logoUrl = $logoId ? wp_get_attachment_image_url($logoId, 'medium') : false;
         $logoSrc = $logoUrl ? (string) $logoUrl : '';
+        $ga4PropertyId = $client?->ga4PropertyId ?? '';
+        $ga4StreamId = $client?->ga4StreamId ?? '';
+        $ga4MeasurementId = $client?->ga4MeasurementId ?? '';
+        $gscSiteProperty = $client?->gscSiteProperty ?? '';
+        $ajaxNonce = wp_create_nonce('fpdms_test_connector');
+        $hasGa4ServiceAccount = CentralServiceAccount::getJson('ga4') !== '';
+        $hasGscServiceAccount = CentralServiceAccount::getJson('gsc') !== '';
+        $documentationUrl = 'https://github.com/francescopasseri/FP-Digital-Marketing-Suite/blob/main/docs/faq.md';
 
         echo '<div class="card" style="max-width:800px;margin-top:20px;padding:20px;">';
         echo '<h2>' . esc_html($title) . '</h2>';
@@ -205,23 +227,88 @@ class ClientsPage
         echo '<td><textarea name="notes" id="fpdms-notes" class="large-text" rows="4">' . esc_textarea($client->notes ?? '') . '</textarea></td></tr>';
 
         echo '</tbody></table>';
+        echo '<input type="hidden" id="fpdms-test-connector-nonce" value="' . esc_attr($ajaxNonce) . '">';
+        echo '<div class="fpdms-connectors" style="margin-top:24px;">';
+        echo '<h2>' . esc_html__('Connettori dati', 'fp-dms') . '</h2>';
+        echo '<div class="notice notice-info"><p>' . esc_html__('Il plugin usa un account di servizio centrale; non serve caricare JSON per cliente.', 'fp-dms') . '</p></div>';
+
+        if (! $hasGa4ServiceAccount) {
+            /* translators: 1: constant name, 2: opening link tag, 3: closing link tag */
+            $ga4DocMessage = sprintf(
+                esc_html__('Definisci la costante %1$s in wp-config.php oppure carica il JSON centrale. Consulta la %2$sdocumentazione%3$s.', 'fp-dms'),
+                'FPDMS_GA4_SERVICE_ACCOUNT',
+                '<a href="' . esc_url($documentationUrl) . '" target="_blank" rel="noopener noreferrer">',
+                '</a>'
+            );
+            echo '<div class="notice notice-error"><p>' . Wp::ksesPost($ga4DocMessage) . '</p></div>';
+        }
+
+        if (! $hasGscServiceAccount) {
+            /* translators: 1: constant name, 2: opening link tag, 3: closing link tag */
+            $gscDocMessage = sprintf(
+                esc_html__('Definisci la costante %1$s in wp-config.php oppure carica il JSON centrale. Consulta la %2$sdocumentazione%3$s.', 'fp-dms'),
+                'FPDMS_GSC_SERVICE_ACCOUNT',
+                '<a href="' . esc_url($documentationUrl) . '" target="_blank" rel="noopener noreferrer">',
+                '</a>'
+            );
+            echo '<div class="notice notice-error"><p>' . Wp::ksesPost($gscDocMessage) . '</p></div>';
+        }
+
+        echo '<h2 class="nav-tab-wrapper" id="fpdms-connector-tabs">';
+        echo '<a href="#" class="nav-tab nav-tab-active" data-target="ga4">' . esc_html__('Google Analytics 4', 'fp-dms') . '</a>';
+        echo '<a href="#" class="nav-tab" data-target="gsc">' . esc_html__('Google Search Console', 'fp-dms') . '</a>';
+        echo '</h2>';
+
+        echo '<div class="fpdms-connector-panel is-active" id="fpdms-connector-panel-ga4">';
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th scope="row"><label for="fpdms-ga4-property-id">' . esc_html__('ID proprietà GA4', 'fp-dms') . '</label></th>';
+        echo '<td><input name="ga4_property_id" type="text" id="fpdms-ga4-property-id" class="regular-text" value="' . esc_attr($ga4PropertyId) . '" placeholder="123456789">';
+        echo '<p class="description">' . esc_html__('Inserisci l’ID numerico della proprietà GA4.', 'fp-dms') . '</p></td></tr>';
+        echo '<tr><th scope="row"><label for="fpdms-ga4-stream-id">' . esc_html__('ID stream GA4', 'fp-dms') . '</label></th>';
+        echo '<td><input name="ga4_stream_id" type="text" id="fpdms-ga4-stream-id" class="regular-text" value="' . esc_attr($ga4StreamId) . '" placeholder="1234567890">';
+        echo '<p class="description">' . esc_html__('Inserisci lo stream Web associato (valore numerico).', 'fp-dms') . '</p></td></tr>';
+        echo '<tr><th scope="row"><label for="fpdms-ga4-measurement-id">' . esc_html__('Measurement ID', 'fp-dms') . '</label></th>';
+        echo '<td><input name="ga4_measurement_id" type="text" id="fpdms-ga4-measurement-id" class="regular-text" value="' . esc_attr($ga4MeasurementId) . '" placeholder="G-XXXXXXX">';
+        echo '<p class="description">' . esc_html__('Formato es. G-XXXXXXXX per il tag di misurazione.', 'fp-dms') . '</p></td></tr>';
+        echo '</tbody></table>';
+        echo '<p><button type="button" class="button fpdms-test-connector" data-connector="ga4"' . ($hasGa4ServiceAccount ? '' : ' disabled') . '>' . esc_html__('Verifica connessione', 'fp-dms') . '</button> <span class="fpdms-connector-status" data-target="ga4"></span></p>';
+        echo '</div>';
+
+        echo '<div class="fpdms-connector-panel" id="fpdms-connector-panel-gsc">';
+        echo '<table class="form-table"><tbody>';
+        echo '<tr><th scope="row"><label for="fpdms-gsc-site-property">' . esc_html__('Proprietà Search Console', 'fp-dms') . '</label></th>';
+        echo '<td><input name="gsc_site_property" type="text" id="fpdms-gsc-site-property" class="regular-text" value="' . esc_attr($gscSiteProperty) . '" placeholder="https://example.com/">';
+        echo '<p class="description">' . esc_html__('Usa l’identificatore esatto (es. sc-domain:example.com o URL completo).', 'fp-dms') . '</p></td></tr>';
+        echo '</tbody></table>';
+        echo '<p><button type="button" class="button fpdms-test-connector" data-connector="gsc"' . ($hasGscServiceAccount ? '' : ' disabled') . '>' . esc_html__('Verifica connessione', 'fp-dms') . '</button> <span class="fpdms-connector-status" data-target="gsc"></span></p>';
+        echo '</div>';
+
+        echo '</div>';
+        echo '<style>.fpdms-connector-panel{display:none;margin-top:16px;}.fpdms-connector-panel.is-active{display:block;}.fpdms-connector-status{margin-left:12px;font-weight:600;}.fpdms-connector-status.success{color:#047857;}.fpdms-connector-status.error{color:#b91c1c;}</style>';
+
         submit_button($client ? __('Update Client', 'fp-dms') : __('Add Client', 'fp-dms'));
         echo '</form>';
         $placeholderText = esc_js(__('No logo selected', 'fp-dms'));
         $chooseLogoText = esc_js(__('Choose logo', 'fp-dms'));
         $useImageText = esc_js(__('Use image', 'fp-dms'));
+        $testingText = esc_js(__('Verifica in corso…', 'fp-dms'));
+        $successText = esc_js(__('Connessione verificata.', 'fp-dms'));
+        $genericErrorText = esc_js(__('Impossibile verificare la connessione.', 'fp-dms'));
 
         $scriptLines = [
             '<script type="text/javascript">',
             '(function($){',
-            '    if (typeof wp === "undefined" || !wp.media) {',
-            '        return;',
-            '    }',
             '    var frame;',
             '    var selectButton = $("#fpdms-logo-select");',
             '    var removeButton = $("#fpdms-logo-remove");',
             '    var input = $("#fpdms-logo-id");',
             '    var preview = $("#fpdms-logo-preview");',
+            '    var testingText = "' . $testingText . '";',
+            '    var successText = "' . $successText . '";',
+            '    var genericErrorText = "' . $genericErrorText . '";',
+            '    var connectorTabs = $("#fpdms-connector-tabs .nav-tab");',
+            '    var connectorPanels = $(".fpdms-connector-panel");',
+            '    var ajaxNonce = $("#fpdms-test-connector-nonce").val();',
             '',
             '    function renderPreview(url){',
             '        preview.empty();',
@@ -232,47 +319,109 @@ class ClientsPage
             '        }',
             '    }',
             '',
-            "    selectButton.data(\"placeholder\", \"{$placeholderText}\");",
+            '    selectButton.data("placeholder", "' . $placeholderText . '");',
             '',
-            '    selectButton.on("click", function(e){',
-            '        e.preventDefault();',
-            '        if (frame) {',
+            '    if (typeof wp !== "undefined" && wp.media) {',
+            '        selectButton.on("click", function(e){',
+            '            e.preventDefault();',
+            '            if (frame) {',
+            '                frame.open();',
+            '                return;',
+            '            }',
+            '',
+            '            frame = wp.media({',
+            '                title: "' . $chooseLogoText . '",',
+            '                button: { text: "' . $useImageText . '" },',
+            '                library: { type: "image" },',
+            '                multiple: false',
+            '            });',
+            '',
+            '            frame.on("select", function(){',
+            '                var attachment = frame.state().get("selection").first().toJSON();',
+            '                input.val(attachment.id);',
+            '                var previewUrl = attachment.sizes && attachment.sizes.medium ? attachment.sizes.medium.url : attachment.url;',
+            '                renderPreview(previewUrl);',
+            '                removeButton.show();',
+            '            });',
+            '',
             '            frame.open();',
-            '            return;',
-            '        }',
-            '',
-            '        frame = wp.media({',
-            "            title: \"{$chooseLogoText}\",",
-            "            button: { text: \"{$useImageText}\" },",
-            '            library: { type: "image" },',
-            '            multiple: false',
             '        });',
             '',
-            '        frame.on("select", function(){',
-            '            var attachment = frame.state().get("selection").first().toJSON();',
-            '            input.val(attachment.id);',
-            '            var previewUrl = attachment.sizes && attachment.sizes.medium ? attachment.sizes.medium.url : attachment.url;',
-            '            renderPreview(previewUrl);',
-            '            removeButton.show();',
+            '        removeButton.on("click", function(e){',
+            '            e.preventDefault();',
+            '            input.val("");',
+            '            renderPreview("");',
+            '            removeButton.hide();',
             '        });',
-            '',
-            '        frame.open();',
-            '    });',
-            '',
-            '    removeButton.on("click", function(e){',
-            '        e.preventDefault();',
-            '        input.val("");',
-            '        renderPreview("");',
-            '        removeButton.hide();',
-            '    });',
+            '    }',
             '',
             '    if (!input.val()) {',
             '        renderPreview("");',
             '    }',
+            '',
+            '    function activateConnector(tab){',
+            '        if (!tab || !tab.length) {',
+            '            return;',
+            '        }',
+            '        connectorTabs.removeClass("nav-tab-active");',
+            '        var current = $(tab);',
+            '        current.addClass("nav-tab-active");',
+            '        var target = current.data("target");',
+            '        connectorPanels.removeClass("is-active");',
+            '        if (target) {',
+            '            $("#fpdms-connector-panel-" + target).addClass("is-active");',
+            '        }',
+            '    }',
+            '',
+            '    connectorTabs.on("click", function(e){',
+            '        e.preventDefault();',
+            '        activateConnector($(this));',
+            '    });',
+            '',
+            '    if (connectorTabs.length) {',
+            '        activateConnector(connectorTabs.first());',
+            '    }',
+            '',
+            '    $(".fpdms-test-connector").on("click", function(e){',
+            '        e.preventDefault();',
+            '        var button = $(this);',
+            '        if (button.is(":disabled")) {',
+            '            return;',
+            '        }',
+            '        var connector = button.data("connector");',
+            '        var status = $(".fpdms-connector-status[data-target=\"" + connector + "\"]");',
+            '        var payload = {',
+            '            action: "fpdms_test_connector",',
+            '            _ajax_nonce: ajaxNonce,',
+            '            connector_type: connector,',
+            '            client_id: $("input[name=client_id]").val() || "0"',
+            '        };',
+            '        if (connector === "ga4") {',
+            '            payload.property_id = $("#fpdms-ga4-property-id").val();',
+            '            payload.stream_id = $("#fpdms-ga4-stream-id").val();',
+            '            payload.measurement_id = $("#fpdms-ga4-measurement-id").val();',
+            '        } else {',
+            '            payload.site_property = $("#fpdms-gsc-site-property").val();',
+            '        }',
+            '        status.removeClass("success error").text(testingText);',
+            '        button.prop("disabled", true);',
+            '        $.post(ajaxurl, payload).done(function(response){',
+            '            if (response && response.success && response.data && response.data.ok) {',
+            '                status.text(response.data.message || successText).removeClass("error").addClass("success");',
+            '            } else if (response && response.data) {',
+            '                status.text(response.data.message || genericErrorText).removeClass("success").addClass("error");',
+            '            } else {',
+            '                status.text(genericErrorText).removeClass("success").addClass("error");',
+            '            }',
+            '        }).fail(function(){',
+            '            status.text(genericErrorText).removeClass("success").addClass("error");',
+            '        }).always(function(){',
+            '            button.prop("disabled", false);',
+            '        });',
+            '    });',
             '})(jQuery);',
             '</script>',
         ];
-
         echo implode("\n", $scriptLines);
         echo '</div>';
     }

--- a/src/Admin/Support/Ajax/TestConnector.php
+++ b/src/Admin/Support/Ajax/TestConnector.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Admin\Support\Ajax;
+
+use FP\DMS\Services\Connectors\CentralServiceAccount;
+use FP\DMS\Services\Connectors\ClientConnectorValidator;
+use FP\DMS\Services\Connectors\ServiceAccountHttpClient;
+use FP\DMS\Support\Wp;
+use function __;
+use function add_action;
+use function current_user_can;
+use function gmdate;
+use function in_array;
+use function is_array;
+use function rawurlencode;
+use function sprintf;
+use function strtotime;
+use function trim;
+use function wp_send_json_error;
+use function wp_send_json_success;
+use function wp_verify_nonce;
+
+class TestConnector
+{
+    public static function register(): void
+    {
+        add_action('wp_ajax_fpdms_test_connector', [self::class, 'handle']);
+    }
+
+    public static function handle(): void
+    {
+        if (! current_user_can('manage_options')) {
+            wp_send_json_error([
+                'ok' => false,
+                'status' => 403,
+                'message' => __('You are not allowed to test connectors.', 'fp-dms'),
+            ], 403);
+        }
+
+        $nonce = Wp::sanitizeTextField($_POST['_ajax_nonce'] ?? '');
+        if (! wp_verify_nonce($nonce, 'fpdms_test_connector')) {
+            wp_send_json_error([
+                'ok' => false,
+                'status' => 403,
+                'message' => __('Security check failed. Refresh the page and try again.', 'fp-dms'),
+            ], 403);
+        }
+
+        $connectorType = Wp::sanitizeKey($_POST['connector_type'] ?? '');
+        if (! in_array($connectorType, ['ga4', 'gsc'], true)) {
+            wp_send_json_error([
+                'ok' => false,
+                'status' => 400,
+                'message' => __('Unknown connector type.', 'fp-dms'),
+            ], 400);
+        }
+
+        $serviceAccountJson = CentralServiceAccount::getJson($connectorType);
+        if ($serviceAccountJson === '') {
+            wp_send_json_error([
+                'ok' => false,
+                'status' => 412,
+                'message' => __('Configure the central service account before running tests.', 'fp-dms'),
+            ]);
+        }
+
+        $client = ServiceAccountHttpClient::fromJson($serviceAccountJson);
+        if (! $client) {
+            wp_send_json_error([
+                'ok' => false,
+                'status' => 400,
+                'message' => __('The central service account JSON is not valid.', 'fp-dms'),
+            ]);
+        }
+
+        if ($connectorType === 'ga4') {
+            self::handleGa4($client);
+
+            return;
+        }
+
+        self::handleGsc($client);
+    }
+
+    private static function handleGa4(ServiceAccountHttpClient $client): void
+    {
+        $propertyId = ClientConnectorValidator::sanitizeGa4PropertyId($_POST['property_id'] ?? '');
+        if ($propertyId === '') {
+            wp_send_json_error([
+                'ok' => false,
+                'status' => 422,
+                'message' => __('Provide a valid GA4 property ID before testing.', 'fp-dms'),
+            ]);
+        }
+
+        $start = gmdate('Y-m-d', strtotime('-3 days'));
+        $end = gmdate('Y-m-d');
+
+        $response = $client->postJson(
+            sprintf('https://analyticsdata.googleapis.com/v1beta/properties/%s:runReport', rawurlencode($propertyId)),
+            [
+                'dateRanges' => [
+                    ['startDate' => $start, 'endDate' => $end],
+                ],
+                'dimensions' => [
+                    ['name' => 'date'],
+                ],
+                'metrics' => [
+                    ['name' => 'activeUsers'],
+                ],
+                'limit' => 3,
+            ],
+            ['https://www.googleapis.com/auth/analytics.readonly']
+        );
+
+        self::dispatchResponse($response, 'ga4');
+    }
+
+    private static function handleGsc(ServiceAccountHttpClient $client): void
+    {
+        $siteProperty = ClientConnectorValidator::sanitizeGscSiteProperty($_POST['site_property'] ?? '');
+        if ($siteProperty === '') {
+            wp_send_json_error([
+                'ok' => false,
+                'status' => 422,
+                'message' => __('Provide a valid Search Console property before testing.', 'fp-dms'),
+            ]);
+        }
+
+        $start = gmdate('Y-m-d', strtotime('-3 days'));
+        $end = gmdate('Y-m-d');
+
+        $response = $client->postJson(
+            sprintf('https://searchconsole.googleapis.com/webmasters/v3/sites/%s/searchAnalytics/query', rawurlencode($siteProperty)),
+            [
+                'startDate' => $start,
+                'endDate' => $end,
+                'dimensions' => ['page'],
+                'rowLimit' => 1,
+            ],
+            ['https://www.googleapis.com/auth/webmasters.readonly']
+        );
+
+        self::dispatchResponse($response, 'gsc');
+    }
+
+    /**
+     * @param array{ok:bool,status:int,body:string,json:array<string,mixed>|null,message:string} $response
+     */
+    private static function dispatchResponse(array $response, string $connectorType): void
+    {
+        if ($response['ok']) {
+            $rows = 0;
+            if (is_array($response['json'])) {
+                if ($connectorType === 'ga4') {
+                    $rows = isset($response['json']['rowCount'])
+                        ? (int) $response['json']['rowCount']
+                        : (is_array($response['json']['rows'] ?? null) ? count($response['json']['rows']) : 0);
+                } else {
+                    $rows = isset($response['json']['rows']) && is_array($response['json']['rows'])
+                        ? count($response['json']['rows'])
+                        : 0;
+                }
+            }
+
+            wp_send_json_success([
+                'ok' => true,
+                'status' => $response['status'],
+                'message' => sprintf(
+                    __('Connection verified. Received %d rows in the last 3 days.', 'fp-dms'),
+                    $rows
+                ),
+            ]);
+        }
+
+        $message = trim($response['message']);
+        if (in_array($response['status'], [403, 404], true)) {
+            if ($connectorType === 'ga4') {
+                $message .= ' ' . __('Ensure the service account email has at least Reader access to the GA4 property.', 'fp-dms');
+            } else {
+                $message .= ' ' . __('Ensure the service account email is a verified owner for this Search Console property.', 'fp-dms');
+            }
+        }
+
+        wp_send_json_error([
+            'ok' => false,
+            'status' => $response['status'],
+            'message' => $message !== '' ? $message : __('Connection failed. Check the property and permissions.', 'fp-dms'),
+            'debug' => [
+                'status' => $response['status'],
+                'body' => $response['body'],
+            ],
+        ]);
+    }
+}

--- a/src/Domain/Entities/Client.php
+++ b/src/Domain/Entities/Client.php
@@ -18,6 +18,10 @@ class Client
         public ?int $logoId,
         public string $createdAt,
         public string $updatedAt,
+        public ?string $ga4PropertyId = null,
+        public ?string $ga4StreamId = null,
+        public ?string $ga4MeasurementId = null,
+        public ?string $gscSiteProperty = null,
     ) {
     }
 
@@ -36,6 +40,10 @@ class Client
             self::normalizeLogoId($row['logo_id'] ?? null),
             (string) ($row['created_at'] ?? ''),
             (string) ($row['updated_at'] ?? ''),
+            self::nullableString($row['ga4_property_id'] ?? null),
+            self::nullableString($row['ga4_stream_id'] ?? null),
+            self::nullableString($row['ga4_measurement_id'] ?? null),
+            self::nullableString($row['gsc_site_property'] ?? null),
         );
     }
 
@@ -54,6 +62,10 @@ class Client
             'logo_id' => $this->logoId,
             'created_at' => $this->createdAt,
             'updated_at' => $this->updatedAt,
+            'ga4_property_id' => $this->ga4PropertyId,
+            'ga4_stream_id' => $this->ga4StreamId,
+            'ga4_measurement_id' => $this->ga4MeasurementId,
+            'gsc_site_property' => $this->gscSiteProperty,
         ];
     }
 
@@ -82,5 +94,16 @@ class Client
         }
 
         return $id;
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
     }
 }

--- a/src/Infra/DB.php
+++ b/src/Infra/DB.php
@@ -43,6 +43,10 @@ class DB
                 logo_id BIGINT UNSIGNED NULL,
                 timezone VARCHAR(64) NOT NULL DEFAULT 'UTC',
                 notes LONGTEXT NULL,
+                ga4_property_id VARCHAR(32) NULL,
+                ga4_stream_id VARCHAR(32) NULL,
+                ga4_measurement_id VARCHAR(32) NULL,
+                gsc_site_property VARCHAR(255) NULL,
                 created_at DATETIME NOT NULL,
                 updated_at DATETIME NOT NULL,
                 PRIMARY KEY  (id)

--- a/src/Services/Connectors/CentralServiceAccount.php
+++ b/src/Services/Connectors/CentralServiceAccount.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Services\Connectors;
+
+use function apply_filters;
+use function constant;
+use function defined;
+use function is_string;
+use function trim;
+
+class CentralServiceAccount
+{
+    public static function getJson(string $type): string
+    {
+        $candidates = [];
+        if ($type === 'ga4') {
+            $candidates[] = 'FPDMS_GA4_SERVICE_ACCOUNT';
+        }
+        if ($type === 'gsc') {
+            $candidates[] = 'FPDMS_GSC_SERVICE_ACCOUNT';
+        }
+
+        $candidates[] = 'FPDMS_SERVICE_ACCOUNT_JSON';
+
+        foreach ($candidates as $constant) {
+            if (defined($constant)) {
+                $value = constant($constant);
+                if (is_string($value) && trim($value) !== '') {
+                    return trim($value);
+                }
+            }
+        }
+
+        $filteredByType = apply_filters('fpdms/central_service_account/' . $type, '');
+        if (is_string($filteredByType) && trim($filteredByType) !== '') {
+            return trim($filteredByType);
+        }
+
+        $generic = apply_filters('fpdms/central_service_account', '', $type);
+        if (is_string($generic) && trim($generic) !== '') {
+            return trim($generic);
+        }
+
+        return '';
+    }
+}

--- a/src/Services/Connectors/ClientConnectorValidator.php
+++ b/src/Services/Connectors/ClientConnectorValidator.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Services\Connectors;
+
+use FP\DMS\Support\Wp;
+
+class ClientConnectorValidator
+{
+    public static function sanitizeGa4PropertyId(mixed $value): string
+    {
+        $digits = preg_replace('/\D+/', '', (string) $value);
+        if (! is_string($digits)) {
+            return '';
+        }
+
+        $normalized = ltrim($digits, '0');
+
+        return $normalized === '' ? '' : $normalized;
+    }
+
+    public static function sanitizeGa4StreamId(mixed $value): string
+    {
+        $digits = preg_replace('/\D+/', '', (string) $value);
+        if (! is_string($digits)) {
+            return '';
+        }
+
+        if ($digits === '') {
+            return '';
+        }
+
+        $normalized = ltrim($digits, '0');
+
+        return $normalized === '' ? '0' : $normalized;
+    }
+
+    public static function sanitizeGa4MeasurementId(mixed $value): string
+    {
+        $candidate = strtoupper(trim((string) $value));
+        if ($candidate === '') {
+            return '';
+        }
+
+        return preg_match('/^G-[A-Z0-9]+$/', $candidate) === 1 ? $candidate : '';
+    }
+
+    public static function sanitizeGscSiteProperty(mixed $value): string
+    {
+        $candidate = trim((string) $value);
+        if ($candidate === '') {
+            return '';
+        }
+
+        if (str_starts_with($candidate, 'sc-domain:')) {
+            $domain = substr($candidate, strlen('sc-domain:'));
+            $domain = strtolower(trim((string) $domain));
+            $domain = preg_replace('/[^a-z0-9\.-]/', '', $domain ?? '');
+            if (! is_string($domain) || $domain === '') {
+                return '';
+            }
+
+            return 'sc-domain:' . $domain;
+        }
+
+        $sanitized = Wp::escUrlRaw($candidate);
+        if ($sanitized === '') {
+            return '';
+        }
+
+        return filter_var($sanitized, FILTER_VALIDATE_URL) !== false ? $sanitized : '';
+    }
+}

--- a/src/Services/Connectors/GA4Provider.php
+++ b/src/Services/Connectors/GA4Provider.php
@@ -8,6 +8,7 @@ use FP\DMS\Support\Dates;
 use FP\DMS\Support\Period;
 use FP\DMS\Support\Wp;
 use function __;
+use function apply_filters;
 
 class GA4Provider implements DataSourceProviderInterface
 {
@@ -195,6 +196,15 @@ class GA4Provider implements DataSourceProviderInterface
             return is_string($value) ? $value : '';
         }
 
-        return (string) ($this->auth['service_account'] ?? '');
+        $serviceAccount = (string) ($this->auth['service_account'] ?? '');
+
+        /**
+         * Allow developers to load the GA4 service account JSON from custom locations.
+         *
+         * @param string $serviceAccount JSON payload used to authenticate with GA4.
+         * @param array<string, mixed> $auth Raw authentication data saved with the data source.
+         * @param array<string, mixed> $config Connector configuration for the data source.
+         */
+        return (string) apply_filters('fpdms/connector/ga4/service_account', $serviceAccount, $this->auth, $this->config);
     }
 }

--- a/src/Services/Connectors/GSCProvider.php
+++ b/src/Services/Connectors/GSCProvider.php
@@ -8,6 +8,7 @@ use FP\DMS\Support\Dates;
 use FP\DMS\Support\Period;
 use FP\DMS\Support\Wp;
 use function __;
+use function apply_filters;
 
 class GSCProvider implements DataSourceProviderInterface
 {
@@ -191,6 +192,15 @@ class GSCProvider implements DataSourceProviderInterface
             return is_string($value) ? $value : '';
         }
 
-        return (string) ($this->auth['service_account'] ?? '');
+        $serviceAccount = (string) ($this->auth['service_account'] ?? '');
+
+        /**
+         * Allow developers to source the Search Console service account JSON dynamically.
+         *
+         * @param string $serviceAccount JSON payload used to authenticate with Search Console.
+         * @param array<string, mixed> $auth Raw authentication data saved with the data source.
+         * @param array<string, mixed> $config Connector configuration for the data source.
+         */
+        return (string) apply_filters('fpdms/connector/gsc/service_account', $serviceAccount, $this->auth, $this->config);
     }
 }

--- a/src/Services/Connectors/MetaAdsProvider.php
+++ b/src/Services/Connectors/MetaAdsProvider.php
@@ -9,6 +9,17 @@ use function __;
 
 class MetaAdsProvider implements DataSourceProviderInterface
 {
+    private const SOURCE = 'meta_ads';
+
+    /** @var array<string, list<string>> */
+    private const METRIC_ALIASES = [
+        'clicks' => ['clicks', 'linkclicks'],
+        'impressions' => ['impressions'],
+        'conversions' => ['conversions', 'results', 'purchases', 'purchase', 'websitepurchases', 'leads'],
+        'cost' => ['cost', 'costusd', 'amountspent*', 'spend*'],
+        'revenue' => ['revenue', 'purchaseconversionvalue*', 'purchasesconversionvalue*'],
+    ];
+
     public function __construct(private array $auth, private array $config)
     {
     }
@@ -31,7 +42,38 @@ class MetaAdsProvider implements DataSourceProviderInterface
 
     public function fetchMetrics(Period $period): array
     {
-        return [];
+        $summary = is_array($this->config['summary'] ?? null) ? $this->config['summary'] : [];
+        $rows = [];
+
+        $dailyRows = [];
+        $daily = $summary['daily'] ?? [];
+
+        if (is_array($daily)) {
+            foreach ($daily as $date => $metrics) {
+                if (! is_array($metrics) || ! preg_match('/^\d{4}-\d{2}-\d{2}$/', (string) $date)) {
+                    continue;
+                }
+
+                $normalized = self::sanitizeMetricMap($metrics);
+                $dailyRows[(string) $date] = $this->decorateRow((string) $date, $normalized, false);
+            }
+        }
+
+        if ($dailyRows !== []) {
+            ksort($dailyRows);
+            $rows = array_values($dailyRows);
+        }
+
+        $summaryMetrics = self::sanitizeMetricMap($summary['metrics'] ?? []);
+        $aggregateRow = $this->decorateRow($period->end->format('Y-m-d'), $summaryMetrics, true);
+
+        if ($this->metricsAreEmpty($summaryMetrics) && $dailyRows !== []) {
+            $aggregateRow = $this->aggregateFromDaily($period, $dailyRows);
+        }
+
+        $rows[] = $aggregateRow;
+
+        return $rows;
     }
 
     public function fetchDimensions(Period $period): array
@@ -42,10 +84,332 @@ class MetaAdsProvider implements DataSourceProviderInterface
     public function describe(): array
     {
         return [
-            'name' => 'meta_ads',
+            'name' => self::SOURCE,
             'label' => __('Meta Ads', 'fp-dms'),
             'credentials' => ['access_token'],
             'config' => ['account_id', 'pixel_id'],
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function ingestCsvSummary(string $csv): array
+    {
+        $csv = trim($csv);
+
+        if ($csv === '') {
+            return [
+                'rows' => 0,
+                'metrics' => self::emptyMetrics(),
+                'daily' => [],
+            ];
+        }
+
+        $lines = preg_split("/(?:\r\n|\r|\n)/", $csv) ?: [];
+
+        if ($lines === []) {
+            return [
+                'rows' => 0,
+                'metrics' => self::emptyMetrics(),
+                'daily' => [],
+            ];
+        }
+
+        $headerLine = array_shift($lines);
+        $headers = $headerLine !== null ? str_getcsv($headerLine) : [];
+        $headerMap = [];
+
+        foreach ($headers as $index => $column) {
+            $headerMap[$index] = self::sanitizeKey($column);
+        }
+
+        $totals = self::emptyMetrics();
+        $dailySummary = [];
+        $rowCount = 0;
+
+        foreach ($lines as $line) {
+            if (trim((string) $line) === '') {
+                continue;
+            }
+
+            $values = str_getcsv((string) $line);
+
+            $normalized = [];
+
+            foreach ($values as $index => $value) {
+                $key = $headerMap[$index] ?? 'col' . $index;
+                $normalized[$key] = $value;
+            }
+
+            $date = trim((string) ($normalized['date'] ?? ''));
+
+            if ($date === '') {
+                continue;
+            }
+
+            $dateKey = substr($date, 0, 10);
+
+            if (! preg_match('/^\d{4}-\d{2}-\d{2}$/', $dateKey)) {
+                continue;
+            }
+
+            $rowCount++;
+
+            $metrics = self::sanitizeMetricMap($normalized);
+
+            $rowMetrics = [
+                'clicks' => self::pickMetric($metrics, self::METRIC_ALIASES['clicks']) ?? 0.0,
+                'impressions' => self::pickMetric($metrics, self::METRIC_ALIASES['impressions']) ?? 0.0,
+                'conversions' => self::pickMetric($metrics, self::METRIC_ALIASES['conversions']) ?? 0.0,
+            ];
+
+            $cost = self::pickMetric($metrics, self::METRIC_ALIASES['cost']);
+            if ($cost !== null && $cost >= 0.0) {
+                $rowMetrics['cost'] = $cost;
+                $totals['cost'] = self::addCurrency($totals['cost'], $cost);
+            }
+
+            $revenue = self::pickMetric($metrics, self::METRIC_ALIASES['revenue']);
+            if ($revenue !== null) {
+                $rowMetrics['revenue'] = $revenue;
+                $totals['revenue'] = self::addCurrency($totals['revenue'], $revenue);
+            }
+
+            $totals['clicks'] += $rowMetrics['clicks'];
+            $totals['impressions'] += $rowMetrics['impressions'];
+            $totals['conversions'] += $rowMetrics['conversions'];
+
+            $dailySummary[$dateKey] = $rowMetrics;
+        }
+
+        return [
+            'rows' => $rowCount,
+            'metrics' => $totals,
+            'daily' => $dailySummary,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $metrics
+     */
+    private function decorateRow(string $date, array $metrics, bool $includeEmptyCosts): array
+    {
+        $row = [
+            'source' => self::SOURCE,
+            'date' => $date,
+            'clicks' => self::pickMetric($metrics, self::METRIC_ALIASES['clicks']) ?? 0.0,
+            'impressions' => self::pickMetric($metrics, self::METRIC_ALIASES['impressions']) ?? 0.0,
+            'conversions' => self::pickMetric($metrics, self::METRIC_ALIASES['conversions']) ?? 0.0,
+        ];
+
+        $cost = self::pickMetric($metrics, self::METRIC_ALIASES['cost']);
+        if ($cost !== null) {
+            $row['cost'] = $cost;
+        } elseif ($includeEmptyCosts) {
+            $row['cost'] = 0.0;
+        }
+
+        $revenue = self::pickMetric($metrics, self::METRIC_ALIASES['revenue']);
+        if ($revenue !== null) {
+            $row['revenue'] = $revenue;
+        } elseif ($includeEmptyCosts) {
+            $row['revenue'] = 0.0;
+        }
+
+        return $row;
+    }
+
+    /**
+     * @param array<string, mixed> $dailyRows
+     */
+    private function aggregateFromDaily(Period $period, array $dailyRows): array
+    {
+        $totals = [
+            'source' => self::SOURCE,
+            'date' => $period->end->format('Y-m-d'),
+            'clicks' => 0.0,
+            'impressions' => 0.0,
+            'conversions' => 0.0,
+            'cost' => 0.0,
+            'revenue' => 0.0,
+        ];
+
+        foreach ($dailyRows as $row) {
+            $totals['clicks'] += (float) ($row['clicks'] ?? 0.0);
+            $totals['impressions'] += (float) ($row['impressions'] ?? 0.0);
+            $totals['conversions'] += (float) ($row['conversions'] ?? 0.0);
+
+            if (isset($row['cost'])) {
+                $totals['cost'] = self::addCurrency($totals['cost'], (float) $row['cost']);
+            }
+
+            if (isset($row['revenue'])) {
+                $totals['revenue'] = self::addCurrency($totals['revenue'], (float) $row['revenue']);
+            }
+        }
+
+        return $totals;
+    }
+
+    /**
+     * @param array<string, mixed> $metrics
+     */
+    private function metricsAreEmpty(array $metrics): bool
+    {
+        foreach ($metrics as $value) {
+            if (self::parseNumber($value) !== null) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<string, mixed> $metrics
+     * @return array<string, mixed>
+     */
+    private static function sanitizeMetricMap(array $metrics): array
+    {
+        $normalized = [];
+
+        foreach ($metrics as $key => $value) {
+            $normalized[self::sanitizeKey((string) $key)] = $value;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param array<string, mixed> $metrics
+     * @param list<string> $aliases
+     */
+    private static function pickMetric(array $metrics, array $aliases): ?float
+    {
+        foreach ($aliases as $alias) {
+            $isPrefix = str_ends_with($alias, '*');
+            $pattern = $isPrefix ? substr($alias, 0, -1) : $alias;
+
+            foreach ($metrics as $key => $value) {
+                if ($key === '') {
+                    continue;
+                }
+
+                if ($isPrefix) {
+                    if (! str_starts_with($key, $pattern)) {
+                        continue;
+                    }
+                } elseif ($key !== $pattern) {
+                    continue;
+                }
+
+                $parsed = self::parseNumber($value);
+
+                if ($parsed !== null) {
+                    return $parsed;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static function sanitizeKey(string $key): string
+    {
+        $key = mb_strtolower($key);
+        $key = preg_replace('/[^a-z0-9]+/', '', $key) ?? '';
+
+        return $key;
+    }
+
+    private static function parseNumber(mixed $value): ?float
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (float) $value;
+        }
+
+        $raw = trim((string) $value);
+        $isNegative = false;
+
+        if ($raw === '' || $raw === '-') {
+            return null;
+        }
+
+        if ($raw[0] === '(' && str_ends_with($raw, ')')) {
+            $raw = substr($raw, 1, -1);
+            $isNegative = true;
+        }
+
+        $stripped = preg_replace('/[^0-9,\.\-]/', '', $raw) ?? '';
+
+        if ($stripped === '' || $stripped === '-' || $stripped === '--') {
+            return null;
+        }
+
+        $hasComma = str_contains($stripped, ',');
+        $hasDot = str_contains($stripped, '.');
+
+        if ($hasComma && $hasDot) {
+            $lastComma = strrpos($stripped, ',');
+            $lastDot = strrpos($stripped, '.');
+
+            if ($lastComma !== false && $lastDot !== false && $lastComma > $lastDot) {
+                $stripped = str_replace('.', '', $stripped);
+                $stripped = str_replace(',', '.', $stripped);
+            } else {
+                $stripped = str_replace(',', '', $stripped);
+            }
+        } elseif ($hasComma) {
+            $parts = explode(',', $stripped);
+            $last = end($parts) ?: '';
+
+            if (strlen($last) === 3 && count($parts) > 1) {
+                $stripped = str_replace(',', '', $stripped);
+            } else {
+                $stripped = str_replace(',', '.', $stripped);
+            }
+        } elseif ($hasDot) {
+            $parts = explode('.', $stripped);
+            $last = end($parts) ?: '';
+
+            if (strlen($last) === 3 && count($parts) > 1) {
+                $stripped = str_replace('.', '', $stripped);
+            }
+        }
+
+        if (! is_numeric($stripped)) {
+            return null;
+        }
+
+        $number = (float) $stripped;
+
+        return $isNegative ? $number * -1 : $number;
+    }
+
+    /**
+     * @return array<string, float>
+     */
+    private static function emptyMetrics(): array
+    {
+        return [
+            'clicks' => 0.0,
+            'impressions' => 0.0,
+            'conversions' => 0.0,
+            'cost' => 0.0,
+            'revenue' => 0.0,
+        ];
+    }
+
+    private static function addCurrency(float $current, float $value): float
+    {
+        $currentCents = (int) round($current * 100);
+        $valueCents = (int) round($value * 100);
+
+        return ($currentCents + $valueCents) / 100.0;
     }
 }

--- a/src/Services/Connectors/ProviderFactory.php
+++ b/src/Services/Connectors/ProviderFactory.php
@@ -32,10 +32,12 @@ class ProviderFactory
                 'summary' => __('Sync engagement metrics directly from GA4.', 'fp-dms'),
                 'description' => __('Use a service account JSON with access to the GA4 property or load it from wp-config.', 'fp-dms'),
                 'steps' => [
-                    __('Create or reuse a Google Cloud service account with access to the GA4 property.', 'fp-dms'),
-                    __('Share the service account email with the property (Admin → Property Access Management).', 'fp-dms'),
-                    __('Optionally define a wp-config constant that contains the JSON if you prefer not to paste it here.', 'fp-dms'),
-                    __('Copy the numeric Property ID from GA4 Admin → Property Settings.', 'fp-dms'),
+                    __('Create or reuse a Google Cloud service account and download the JSON key for GA4.', 'fp-dms'),
+                    __('Share the service account email with the property (Admin → Property Access Management) using the Editor role or higher.', 'fp-dms'),
+                    __('Decide how to provide the JSON: set “Credential Source” to “Use wp-config constant” and enter the constant name (e.g. FPDMS_GA4_SERVICE_ACCOUNT) or choose “Paste JSON manually” and paste the entire file.', 'fp-dms'),
+                    __('Advanced: developers can filter fpdms/connector/ga4/service_account to load the JSON from secrets managers or external stores.', 'fp-dms'),
+                    __('Copy the numeric Property ID from GA4 Admin → Property Settings and paste it into the form.', 'fp-dms'),
+                    __('Save the data source and click “Test connection” to confirm the suite can read the property.', 'fp-dms'),
                 ],
                 'fields' => [
                     'auth' => [
@@ -74,10 +76,12 @@ class ProviderFactory
                 'summary' => __('Bring in organic search queries and clicks.', 'fp-dms'),
                 'description' => __('Provide a service account JSON (or load it from wp-config) and the verified site URL.', 'fp-dms'),
                 'steps' => [
-                    __('Generate a service account JSON and add the client email as an owner in Search Console.', 'fp-dms'),
-                    __('Optionally define a wp-config constant that contains the JSON if you prefer not to paste it here.', 'fp-dms'),
-                    __('Confirm the property you want to track is verified in the same Search Console account.', 'fp-dms'),
-                    __('Copy the exact site URL (including protocol) from the property settings.', 'fp-dms'),
+                    __('Generate a service account JSON and download the key for Google Search Console.', 'fp-dms'),
+                    __('Add the service account email as a full owner in Search Console (Settings → Users and permissions).', 'fp-dms'),
+                    __('Pick how you will load the JSON: select “Use wp-config constant” and enter the constant name (e.g. FPDMS_GSC_SERVICE_ACCOUNT) or keep “Paste JSON manually” and paste the key.', 'fp-dms'),
+                    __('Advanced: developers can filter fpdms/connector/gsc/service_account to load the JSON from secrets managers or external stores.', 'fp-dms'),
+                    __('Confirm the property you want to track is verified in the same Search Console account and copy the exact site URL or domain identifier.', 'fp-dms'),
+                    __('Save the data source and use “Test connection” to verify clicks and impressions can be retrieved.', 'fp-dms'),
                 ],
                 'fields' => [
                     'auth' => [

--- a/src/Services/Connectors/ServiceAccountHttpClient.php
+++ b/src/Services/Connectors/ServiceAccountHttpClient.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Services\Connectors;
+
+use FP\DMS\Support\Wp;
+use function __;
+use function base64_encode;
+use function function_exists;
+use function implode;
+use function is_array;
+use function json_decode;
+use function json_encode;
+use function openssl_free_key;
+use function openssl_pkey_get_private;
+use function openssl_sign;
+use function rtrim;
+use function strtr;
+use function time;
+use function trim;
+
+class ServiceAccountHttpClient
+{
+    /** @var array<string, mixed> */
+    private array $credentials;
+
+    /**
+     * @param array<string, mixed> $credentials
+     */
+    private function __construct(array $credentials)
+    {
+        $this->credentials = $credentials;
+    }
+
+    public static function fromJson(string $json): ?self
+    {
+        $decoded = json_decode($json, true);
+        if (! is_array($decoded)) {
+            return null;
+        }
+
+        $clientEmail = isset($decoded['client_email']) ? trim((string) $decoded['client_email']) : '';
+        $privateKey = isset($decoded['private_key']) ? (string) $decoded['private_key'] : '';
+
+        if ($clientEmail === '' || trim($privateKey) === '') {
+            return null;
+        }
+
+        return new self($decoded);
+    }
+
+    /**
+     * @param string[] $scopes
+     *
+     * @return array{ok:bool,token?:string,message?:string,status?:int}
+     */
+    public function fetchAccessToken(array $scopes): array
+    {
+        if (! function_exists('openssl_sign')) {
+            return [
+                'ok' => false,
+                'message' => __('The PHP OpenSSL extension is required to sign service account tokens.', 'fp-dms'),
+                'status' => 0,
+            ];
+        }
+
+        $assertion = $this->buildAssertion($scopes);
+        if ($assertion === null) {
+            return [
+                'ok' => false,
+                'message' => __('Unable to sign the service account assertion.', 'fp-dms'),
+                'status' => 0,
+            ];
+        }
+
+        $response = Wp::remotePost('https://oauth2.googleapis.com/token', [
+            'timeout' => 20,
+            'body' => [
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion' => $assertion,
+            ],
+        ]);
+
+        if (Wp::isWpError($response)) {
+            return [
+                'ok' => false,
+                'message' => Wp::wpErrorMessage($response),
+                'status' => 0,
+            ];
+        }
+
+        $status = Wp::remoteRetrieveResponseCode($response);
+        $body = Wp::remoteRetrieveBody($response);
+        $decoded = json_decode($body, true);
+
+        if ($status !== 200 || ! is_array($decoded) || empty($decoded['access_token'])) {
+            $message = '';
+            if (is_array($decoded) && isset($decoded['error_description'])) {
+                $message = (string) $decoded['error_description'];
+            } elseif (is_array($decoded) && isset($decoded['error'])) {
+                $message = (string) $decoded['error'];
+            } else {
+                $message = $body;
+            }
+
+            return [
+                'ok' => false,
+                'message' => trim($message),
+                'status' => $status,
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'token' => (string) $decoded['access_token'],
+            'status' => $status,
+        ];
+    }
+
+    /**
+     * @param string[] $scopes
+     * @param array<string,mixed> $body
+     *
+     * @return array{ok:bool,status:int,body:string,json:array<string,mixed>|null,message:string}
+     */
+    public function postJson(string $url, array $body, array $scopes): array
+    {
+        $token = $this->fetchAccessToken($scopes);
+        if (! $token['ok']) {
+            return [
+                'ok' => false,
+                'status' => $token['status'] ?? 0,
+                'body' => '',
+                'json' => null,
+                'message' => $token['message'] ?? '',
+            ];
+        }
+
+        $response = Wp::remotePost($url, [
+            'timeout' => 30,
+            'headers' => [
+                'Authorization' => 'Bearer ' . $token['token'],
+                'Content-Type' => 'application/json',
+            ],
+            'body' => Wp::jsonEncode($body) ?: '{}',
+        ]);
+
+        if (Wp::isWpError($response)) {
+            return [
+                'ok' => false,
+                'status' => 0,
+                'body' => '',
+                'json' => null,
+                'message' => Wp::wpErrorMessage($response),
+            ];
+        }
+
+        $status = Wp::remoteRetrieveResponseCode($response);
+        $rawBody = Wp::remoteRetrieveBody($response);
+        $decoded = json_decode($rawBody, true);
+
+        $message = '';
+        if ($status < 200 || $status >= 300) {
+            if (is_array($decoded)) {
+                $message = (string) ($decoded['error']['message'] ?? $decoded['message'] ?? $rawBody);
+            } else {
+                $message = $rawBody;
+            }
+        }
+
+        return [
+            'ok' => $status >= 200 && $status < 300,
+            'status' => $status,
+            'body' => $rawBody,
+            'json' => is_array($decoded) ? $decoded : null,
+            'message' => trim($message),
+        ];
+    }
+
+    /**
+     * @param string[] $scopes
+     */
+    private function buildAssertion(array $scopes): ?string
+    {
+        $header = ['alg' => 'RS256', 'typ' => 'JWT'];
+        $now = time();
+        $payload = [
+            'iss' => (string) $this->credentials['client_email'],
+            'scope' => implode(' ', $scopes),
+            'aud' => 'https://oauth2.googleapis.com/token',
+            'exp' => $now + 3600,
+            'iat' => $now,
+        ];
+
+        $segments = [
+            $this->base64UrlEncode(json_encode($header) ?: ''),
+            $this->base64UrlEncode(json_encode($payload) ?: ''),
+        ];
+
+        $input = implode('.', $segments);
+        $privateKey = openssl_pkey_get_private((string) $this->credentials['private_key']);
+        if ($privateKey === false) {
+            return null;
+        }
+
+        $signature = '';
+        $result = openssl_sign($input, $signature, $privateKey, 'sha256');
+        openssl_free_key($privateKey);
+
+        if (! $result) {
+            return null;
+        }
+
+        $segments[] = $this->base64UrlEncode($signature);
+
+        return implode('.', $segments);
+    }
+
+    private function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+}

--- a/tests/Unit/ClientConnectorValidatorTest.php
+++ b/tests/Unit/ClientConnectorValidatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FP\DMS\Tests\Unit;
+
+use FP\DMS\Services\Connectors\ClientConnectorValidator;
+use PHPUnit\Framework\TestCase;
+
+final class ClientConnectorValidatorTest extends TestCase
+{
+    public function testSanitizeGa4PropertyIdAcceptsDigits(): void
+    {
+        $this->assertSame('123456', ClientConnectorValidator::sanitizeGa4PropertyId(' 123456 '));
+    }
+
+    public function testSanitizeGa4PropertyIdRemovesNonDigits(): void
+    {
+        $this->assertSame('400987654321', ClientConnectorValidator::sanitizeGa4PropertyId('ga4-00987654321'));
+    }
+
+    public function testSanitizeGa4PropertyIdReturnsEmptyForInvalid(): void
+    {
+        $this->assertSame('', ClientConnectorValidator::sanitizeGa4PropertyId('abc'));
+    }
+
+    public function testSanitizeGa4StreamIdKeepsZeroWhenAllZeros(): void
+    {
+        $this->assertSame('0', ClientConnectorValidator::sanitizeGa4StreamId('0000'));
+    }
+
+    public function testSanitizeGa4StreamIdStripsNonDigits(): void
+    {
+        $this->assertSame('876500', ClientConnectorValidator::sanitizeGa4StreamId('s8765-00'));
+    }
+
+    public function testSanitizeGa4MeasurementIdNormalizesUppercase(): void
+    {
+        $this->assertSame('G-ABCDEFG1', ClientConnectorValidator::sanitizeGa4MeasurementId('g-abcdefg1'));
+    }
+
+    public function testSanitizeGa4MeasurementIdRejectsInvalidFormat(): void
+    {
+        $this->assertSame('', ClientConnectorValidator::sanitizeGa4MeasurementId('G-abc_def'));
+    }
+
+    public function testSanitizeGscSitePropertyAllowsDomainFormat(): void
+    {
+        $this->assertSame('sc-domain:example.org', ClientConnectorValidator::sanitizeGscSiteProperty('sc-domain:Example.org'));
+    }
+
+    public function testSanitizeGscSitePropertyRejectsInvalidDomain(): void
+    {
+        $this->assertSame('', ClientConnectorValidator::sanitizeGscSiteProperty('sc-domain:???'));
+    }
+
+    public function testSanitizeGscSitePropertyValidatesUrls(): void
+    {
+        $this->assertSame('https://example.com/', ClientConnectorValidator::sanitizeGscSiteProperty('https://example.com/'));
+    }
+
+    public function testSanitizeGscSitePropertyRejectsInvalidUrls(): void
+    {
+        $this->assertSame('', ClientConnectorValidator::sanitizeGscSiteProperty('notaurl'));
+    }
+}


### PR DESCRIPTION
## Summary
- normalize Meta Ads summary metrics using alias mapping and locale-aware number parsing
- add CSV summary ingestion helper that skips negative refunds and rolls up totals

## Testing
- vendor/bin/phpunit --bootstrap tests/bootstrap.php --testdox tests/Unit

------
https://chatgpt.com/codex/tasks/task_e_68e26d3b4e90832f96efcd3581216d9b